### PR TITLE
Sensor definitions for Gigabyte Aorus Xtreme TRX40

### DIFF
--- a/GA-TRX40-AORUS-XTREME.conf
+++ b/GA-TRX40-AORUS-XTREME.conf
@@ -1,0 +1,37 @@
+chip "it8688-isa-0a40"
+        label fan1 "cpu0"
+        label fan2 "mos"
+        label fan3 "sys2"
+        label fan4 "pch"
+        label fan5 "opt"
+        label temp1 "mb_sys1"
+        label temp2 "vrmmos"
+        label temp3 "pch"
+        label temp4 "mb_sys2"
+        label temp5 "cpu"
+        label temp6 "ec1"
+        ignore intrusion0
+
+chip "it8688-isa-0a60"
+        label fan1 "pump5a"
+        label fan2 "pump6"
+        label fan3 "sys4"
+        ignore fan4
+        ignore fan5
+        ignore fan6
+        label temp1 "pciex162"
+        label temp2 "ec2"
+        label temp3 "pciex161"
+        ignore temp4
+        ignore temp5
+        ignore temp6
+        ignore in0
+        ignore in1
+        ignore in2
+        ignore in3
+        ignore in4
+        ignore in5
+        ignore in6
+        ignore in7
+        ignore in8
+        ignore intrusion0


### PR DESCRIPTION
Taken from https://nick-black.com/dankwiki/index.php/Gigabyte_Aorus_Xtreme_TRX40, where I have been tracking these for a few months via my own personal Aorus Xtreme TRX40.