### PR TITLE
Initial support for ASUS PRIME B450-PLUS

### DIFF
--- a/Sensors configs/ASUS_PRIME_B450-PLUS.conf
+++ b/Sensors configs/ASUS_PRIME_B450-PLUS.conf
@@ -1,0 +1,49 @@
+# ASUS PRIME B450-PLUS
+#
+# dmi: Board Manufacturer: ASUSTeK COMPUTER INC.
+# dmi: Board Product Name: PRIME B450-PLUS
+# dmi: BIOS Version: 4003 (2023/03/21)
+#
+# Notes:
+# - in0 is CPU voltage (fluctuates a lot with load)
+# - in0..4 are in BIOS order (best guess)
+# - temp1..2 are in BIOS order (best guess)
+# - fans 1-3,6 tested manually
+#   -> assuming fan4 is CHA_FAN3
+# - in7 gives reading - what is it?
+# - in8 seems to be BIOS battery
+# - temp3 is not in BIOS
+#   -> follows CPU temp, not as high
+#   -> rises slower, falls slower
+
+chip "it8665-isa-0290"
+    label in0 "VDDCR"
+    label in1 "+3.3V"
+        compute in1 @ * 1.33, @ / 1.33
+    label in2 "+5.0V"
+        compute in2 @ * 2.5, @ / 2.5
+    label in3 "+12.0V"
+        compute in3 @ * 6, @ / 6
+    ignore in4
+    ignore in5
+    ignore in6
+    label in7 "3VSB"
+    label in8 "VBAT"
+
+    label fan1 "CPU_FAN"
+    label fan2 "CHA_FAN1"
+    label fan3 "CHA_FAN2"
+    label fan4 "CHA_FAN3"
+    ignore fan5
+    label fan6 "AIO_PUMP"
+
+    label temp1 "CPU"
+    label temp2 "Motherboard"
+    label temp3 "System"
+
+    # These mirror temp3
+    ignore temp4
+    ignore temp5
+    ignore temp6
+
+    ignore intrusion0


### PR DESCRIPTION
Initial support for ASUS PRIME B450-PLUS, which has ITE IT8665E chip.

dmi: Board Manufacturer: ASUSTeK COMPUTER INC.
dmi: Board Product Name: PRIME B450-PLUS
dmi: BIOS Version: 4003 (2023/03/21)

Notes:

- in0 is CPU voltage (fluctuates a lot with load)
- in0..4 are in BIOS order (best guess)
- temp1..2 are in BIOS order (best guess)
- fans 1-3,6 tested manually
  - &rarr; assuming fan4 is CHA_FAN3
- in7 gives reading - what is it?
- in8 seems to be BIOS battery
- temp3 is not in BIOS
  - &rarr; follows CPU temp, not as high
  - &rarr; rises slower, falls slower