### PR TITLE
Add X570 AORUS ULTRA to it87_dmi_table

### DIFF
--- a/it87.c
+++ b/it87.c
@@ -4520,6 +4520,9 @@ static const struct dmi_system_id it87_dmi_table[] __initconst = {
 	IT87_DMI_MATCH_GBT("X570 AORUS PRO WIFI", it87_dmi_cb,
 			   &it87_acpi_ignore),
 		/* IT8688E + IT8792E/IT8795E */
+	IT87_DMI_MATCH_GBT("X570 AORUS ULTRA", it87_dmi_cb,
+			   &it87_acpi_ignore),
+		/* IT8688E + IT8792E/IT8795E */
 	IT87_DMI_MATCH_GBT("X570 I AORUS PRO WIFI", it87_dmi_cb,
 			   &it87_acpi_ignore),
 		/* IT8688E */


### PR DESCRIPTION
I own the rev. 1.0 of Gigabyte X570 AORUS ULTRA motherboard and it is essentially the same as the AORUS PRO model. With this I don't need to specify the "ignore_resource_conflict" module parameter.

Both chips are detected and the sensors work fine with the GA-X570-AORUS-PRO configuration on kernel 6.7.7 + dkms.