### PR TITLE
 Adding X570 AORUS ELITE to it87_dmi_table and a corresponding sensors config

### DIFF
--- a/Sensors configs/GA-X570-AORUS-ELITE.conf
+++ b/Sensors configs/GA-X570-AORUS-ELITE.conf
@@ -1,0 +1,57 @@
+#  Gigabyte X570 AORUS ELITE (rev 1.0)
+#
+#  sensors-detect 3.6.0 report is as:
+#       System: Gigabyte Technology Co., Ltd. X570 AORUS ELITE [-CF]
+
+
+# Parsed by hand to mimic other config diles from dmesg output, not sure how
+#
+# dmi: Board Manufacturer: Gigabyte Technology Co., Ltd.
+# dmi: Board Version: -CF
+# dmi: Board Product Name: X570 AORUS ELITE
+# dmi: BIOS Version: F39 03/22/2024
+# dmi: BIOS Revision: 5.17
+#
+# 2024-05-24 Alex Lebedev
+# Based on GA-X570-AORUS-PRO.conf  by Atom of Justice 2022-12-16
+
+# I didn't dig at this too much please update if doens't work for you.
+
+chip "acpitz-acpi-0"
+	# These will provably never function (analysis of disassembled ACPI tables shows that for some reason,
+	# on my mobo these are hardcoded to always return 290 Kelvins)
+	ignore temp1
+	ignore temp2
+
+chip "it8688-isa-0a40"
+	# Beware, this sometimes reports unrealistic values (300-400mV). Could it be due to C-states?
+	label in0 "CPU VCORE"
+
+	label in1 "+3.3V"
+	label in2 "+12V"
+	label in3 "+5V"
+	label in4 "CPU VCORE SoC"
+	label in5 "CPU VDDP"
+	label in6 "DRAM CH(A/B)"
+	label in7 "3VSB"
+	label in8 "VBAT"
+
+	compute in1 @ * (33/20), @ / (33/20)
+	compute in2 @ * (120/20), @ / (120/20)
+	compute in3 @ * (50/20), @ / (50/20)
+
+	label fan1 "CPU_FAN"
+	label fan2 "SYS_FAN1"
+	label fan3 "SYS_FAN2"
+	label fan4 "PCH_FAN"  # AKA SYS_FAN3
+	label fan5 "CPU_OPT"
+
+	label temp1 "System1"
+	label temp2 "EC_TEMP1"  # Will show -55C if open circuit (no thermistor plugged in)
+	#ignore temp2  # Reenable if thermistor installed (removing it so it doesn't confuse UIs)
+	label temp3 "CPU"
+	label temp4 "PCIEX16"
+	label temp5 "VRM MOS"
+	label temp6 "PCH"
+
+	ignore intrusion0

--- a/it87.c
+++ b/it87.c
@@ -3950,7 +3950,7 @@ static void it87_start_monitoring(struct it87_data *data)
 		    (data->read(data, IT87_REG_CONFIG) & 0x3e)
 		    | (update_vbat ? 0x41 : 0x01));
 }
-	
+
 /* Called when we have found a new IT87. */
 static void it87_init_device(struct platform_device *pdev)
 {
@@ -4508,6 +4508,9 @@ static const struct dmi_system_id it87_dmi_table[] __initconst = {
 	IT87_DMI_MATCH_GBT("B560I AORUS PRO AX", it87_dmi_cb,
 			   &it87_acpi_ignore),
 		/* IT8689E */
+	IT87_DMI_MATCH_GBT("X570 AORUS ELITE", it87_dmi_cb,
+			   &it87_acpi_ignore),
+		/* IT8688E */
 	IT87_DMI_MATCH_GBT("X570 AORUS ELITE WIFI", it87_dmi_cb,
 			   &it87_acpi_ignore),
 		/* IT8688E */


### PR DESCRIPTION
I'm copying a  @futant's [pull request f40148e](https://github.com/frankcrawford/it87/commit/f40148e0478c8f4adec6defd0a8447f8758c4ef8)   because it is more or less the same change.

I own  Gigabyte X570 AORUS  ELITE rev 1.0 motherboard and it is essentially the same as the  X570 AORUS ELITE WIFI.

With this I don't need to specify the "ignore_resource_conflict" module parameter and have nice output for sensors. 


Chip is detected and the sesors appear to work fine with the config GA-X570-AORUS-ELITE.conf
ubuntu 24.04  kernel 6.8.0-31-generic  + dkms/


Thank you for your work. 