### PR TITLE
Add IT8785E

### DIFF
--- a/it87.c
+++ b/it87.c
@@ -42,6 +42,7 @@
  *            IT8781F  Super I/O chip w/LPC interface
  *            IT8782F  Super I/O chip w/LPC interface
  *            IT8783E/F Super I/O chip w/LPC interface
+ *            IT8785E  Super I/O chip w/LPC interface
  *            IT8786E  Super I/O chip w/LPC interface
  *            IT8790E  Super I/O chip w/LPC interface
  *            IT8792E  Super I/O chip w/LPC interface
@@ -80,7 +81,7 @@
 
 enum chips { it87, it8712, it8716, it8718, it8720, it8721, it8728, it8732,
 	     it8736, it8738,
-	     it8771, it8772, it8781, it8782, it8783, it8786, it8790,
+	     it8771, it8772, it8781, it8782, it8783, it8785, it8786, it8790,
 	     it8792, it8603, it8606, it8607, it8613, it8620, it8622, it8625,
 	     it8628, it8655, it8665, it8686, it8688, it8689, it87952 };
 
@@ -173,6 +174,7 @@ static inline void superio_exit(int ioreg, bool noexit)
 #define IT8781F_DEVID 0x8781
 #define IT8782F_DEVID 0x8782
 #define IT8783E_DEVID 0x8783
+#define IT8785E_DEVID 0x8785
 #define IT8786E_DEVID 0x8786
 #define IT8790E_DEVID 0x8790
 #define IT8603E_DEVID 0x8603
@@ -569,6 +571,17 @@ static const struct it87_devices it87_devices[] = {
 		.num_temp_offset = 3,
 		.num_temp_map = 3,
 		.old_peci_mask = 0x4,
+	},
+	[it8785] = {
+		.name = "it8785",
+		.model = "IT8785E",
+		.features = FEAT_NEWER_AUTOPWM | FEAT_12MV_ADC | FEAT_16BIT_FANS
+		  | FEAT_TEMP_PECI | FEAT_IN7_INTERNAL
+		  | FEAT_PWM_FREQ2 | FEAT_FANCTL_ONOFF,
+		.num_temp_limit = 3,
+		.num_temp_offset = 3,
+		.num_temp_map = 3,
+		.peci_mask = 0x07,
 	},
 	[it8786] = {
 		.name = "it8786",
@@ -3187,6 +3200,9 @@ static int __init it87_find(int sioaddr, unsigned short *address,
 	case IT8783E_DEVID:
 		sio_data->type = it8783;
 		break;
+	case IT8785E_DEVID:
+		sio_data->type = it8785;
+		break;
 	case IT8786E_DEVID:
 		sio_data->type = it8786;
 		break;
@@ -3722,7 +3738,10 @@ static int __init it87_find(int sioaddr, unsigned short *address,
 			sio_data->skip_fan |= BIT(2);
 
 		/* Check if fan2 is there or not */
-		reg = superio_inb(sioaddr, IT87_SIO_GPIO5_REG);
+		if (sio_data->type == it8785)
+			reg = superio_inb(sioaddr, IT87_SIO_GPIO4_REG);
+		else
+			reg = superio_inb(sioaddr, IT87_SIO_GPIO5_REG);
 		if (reg & BIT(1))
 			sio_data->skip_pwm |= BIT(1);
 		if (reg & BIT(2))


### PR DESCRIPTION
I bought a mother with IT8785E chip which is not supported for now. The [motherboard web page](https://www.jetwaycomputer.com/NC8H.html) has [Watchdog/GPIO sample code](https://www.jetwaycomputer.com/download/ITE/ite8785e_wdt_gpio.zip). Reading this sample code, I guess most things should be compatible with other IT87 chip. As the sample code has a `8786 sample code` folder, I guess this chip resembles 8786 most.

I make some very small modifications to make `it87` module load on this chip. The fan speed results are almost the same to fan speed values in BIOS. I'm not familiar with voltage values so those are not throughly verified.

Note that this chip on motherboard is using index register `0x4e`. Not sure whether this is determined by chip or by motherboard.

The motherboard has 2 fans but only fan1 is recongnized at first.  I tested all the GPIO registers' values by adding printing code and here's the result:

```
it87: gpio1 reg value 0x67
it87: gpio2 reg value 0xcc
it87: gpio3 reg value 0xec
it87: gpio4 reg value 0xc3
it87: gpio5 reg value 0x4
it87: gpio9 reg value 0x0
```

GPIO 4 is the only register that does not skip fan so I used this register. But the value of this register will skip pwm, which I guess is not correct because the motherboard has 4 pin pwm fan connector.