### PR TITLE
Add config for ASUS PRIME B350-PLUS.

### DIFF
--- a/Sensors configs/ASUS-PRIME-B350-PLUS.conf
+++ b/Sensors configs/ASUS-PRIME-B350-PLUS.conf
@@ -1,0 +1,67 @@
+# Manufacturer: ASUSTeK COMPUTER INC.
+# Product Name: PRIME B350-PLUS
+
+# sensor info from testing and HWiNFO on Windows
+# some limits might need changing depending on hardware
+
+chip "it8655-*"
+	# CPU voltage, 0.2V to 1.5V
+	label in0 "VDDCR CPU"
+	set in0_min 0.15
+	set in0_max 1.55
+	# 2.5V, name from HWiNFO
+	label in1 "Vccp2"
+	set in1_min 2.5 * 0.97
+	set in1_max 2.5 * 1.03
+	# 12V
+	label in2 "+12V"
+	compute in2 @ * 6, @ / 6
+	set in2_min 12 * 0.97
+	set in2_max 12 * 1.03
+	# 5V
+	label in3 "+5V"
+	compute in3 @ * 2.5, @ / 2.5
+	set in3_min 5 * 0.97
+	set in3_max 5 * 1.03
+	# unused?
+	ignore in4
+	ignore in5
+	ignore in6
+	# 3.3V standby
+	label in7 "3VSB"
+	set in7_min 3.3 * 0.97
+	set in7_max 3.3 * 1.03
+	# 3V battery
+	label in8 "Vbat"
+	# 3.3V
+	label in9 "+3.3V"
+	#
+	# CPU fan connector
+	label fan1 "CPU_FAN"
+	set fan1_min 1
+	# back case fan connector
+	label fan2 "CHA_FAN1"
+	set fan2_min 0
+	# top case fan connector
+	label fan3 "CHA_FAN2"
+	set fan3_min 0
+	#
+	# CPU temperature
+	# early Ryzens should be under 75°C, later ones can reach 95°C
+	label temp1 "CPU"
+	set temp1_min 1
+	set temp1_max 75
+	# temperature sensors in various places on the mainboard
+	label temp2 "MB"
+	set temp2_min 1
+	set temp2_max 75
+	label temp3 "SYS"
+	set temp3_min 1
+	set temp3_max 75
+	# same as temp3
+	ignore temp4
+	ignore temp5
+	ignore temp6
+	#
+	# no connector for an intrusion sensor on this board
+	ignore intrusion0


### PR DESCRIPTION
The module seems to work fine on that board as is, and with this configuration the `sensors` output corresponds to hardware / BIOS / HWINFO on Windows as far as I can tell.

The limits are ok as far as there's no `ALARM`s anymore, but might need adjustment for different hardware / user preference (e.g. ATX voltage tolerances are at least 5% instead of the 3% I used here).

There's some noticeable differences to the B450-PLUS from #13, which might indicate errors in that file, or maybe it's just due to different hardware.