### PR TITLE
Add X870 EAGLE WIFI7

### DIFF
--- a/Sensors configs/GA-X870-EAGLE-WIFI7.conf
+++ b/Sensors configs/GA-X870-EAGLE-WIFI7.conf
@@ -1,0 +1,45 @@
+# Gigabyte X870 EAGLE WIFI7
+#
+# dmi: Board Manufacturer: Gigabyte Technology Co., Ltd.        
+# dmi: Board Product Name: X870 EAGLE WIFI7
+# dmi: BIOS Version: F3
+#
+# 2025-01-02 Flat
+# based on
+# Gigabyte Z690 AORUS PRO DDR4 (rev 1.0)
+# 2022-02-13 Frank Crawford
+# 
+# 
+
+# ITE IT8696E
+chip "it8696-*"
+
+	label in0 "CPU VCORE"
+	label in1 "+3.3V"
+	compute in1 @*((6.49/10)+1), @/((6.49/10)+1)
+	label in2 "+12V"
+	compute in2 @*((50/10)+1), @/((50/10)+1)
+	label in3 "+5V"
+	compute in3 @*((15/10)+1), @/((15/10)+1)
+	label in4 "CPU VCORE SoC"
+	label in5 "CPU VCORE Misc"
+	label in6 "CPU VDDIO Memory"
+	label in7 "+3VSB"
+	label in8 "CMOS Battery"
+
+
+	label fan1 "CPU_FAN"
+	label fan2 "SYS_FAN1"
+	label fan3 "SYS_FAN2"
+	label fan4 "SYS_FAN3"
+	label fan5 "CPU_OPT"
+	label fan6 "SYS_FAN4"
+
+	label temp1 "System 1"
+	label temp2 "PCH"
+	label temp3 "CPU"
+	label temp4 "PCIEX16"
+	label temp5 "VRM MOS"
+	#label temp6 "External #1" # Will show -55C if open circuit (no thermistor plugged in)
+	ignore temp6
+	ignore intrusion0

--- a/it87.c
+++ b/it87.c
@@ -4617,6 +4617,8 @@ static const struct dmi_system_id it87_dmi_table[] __initconst = {
 		/* IT8696E*/
 	IT87_DMI_MATCH_GBT("X870 GAMING WIFI6", it87_dmi_cb, &it87_acpi_ignore),
 		/* IT8696E*/
+	IT87_DMI_MATCH_GBT("X870 EAGLE WIFI7", it87_dmi_cb, &it87_acpi_ignore),
+		/* IT8696E*/
 	IT87_DMI_MATCH_VND("nVIDIA", "FN68PT", it87_dmi_cb, &nvidia_fn68pt),
 	{ }
 };


### PR DESCRIPTION
I just copied https://github.com/frankcrawford/it87/pull/40 and it seems to work, ok? I really don't know what I am doing, but I can finally turn down my fans.

```
it8696-isa-0a40
Adapter: ISA adapter
in0:         516.00 mV (min =  +0.00 V, max =  +3.06 V)
in1:           1.98 V  (min =  +0.00 V, max =  +3.06 V)
in2:           2.00 V  (min =  +0.00 V, max =  +3.06 V)
in3:           2.00 V  (min =  +0.00 V, max =  +3.06 V)
in4:           1.06 V  (min =  +0.00 V, max =  +3.06 V)
in5:           1.14 V  (min =  +0.48 V, max =  +3.06 V)  ALARM
in6:           1.14 V  (min =  +0.00 V, max =  +3.06 V)  ALARM
3VSB:          3.31 V  (min =  +0.00 V, max =  +6.12 V)
Vbat:          3.12 V  
+3.3V:         3.07 V  
fan1:         498 RPM  (min =    0 RPM)
fan2:         593 RPM  (min =    0 RPM)
fan3:         436 RPM  (min =    0 RPM)
fan4:           0 RPM  (min =    0 RPM)
fan5:         515 RPM  (min =    0 RPM)
fan6:         689 RPM  (min =    0 RPM)
temp1:        +29.0°C  (low  = +127.0°C, high = +127.0°C)
temp2:        +52.0°C  (low  = +127.0°C, high = +127.0°C)
temp3:        +44.0°C  (low  = +127.0°C, high = +127.0°C)
temp4:        +40.0°C  (low  = +127.0°C, high = +127.0°C)
temp5:        +45.0°C  (low  = +127.0°C, high = +127.0°C)
temp6:         +0.0°C  (low  =  +0.0°C, high = +127.0°C)
intrusion0:  ALARM
```