### PR TITLE
Add sensor config for Beelink SEi12 series

### DIFF
--- a/Sensors configs/Beelink-SEi12.conf
+++ b/Sensors configs/Beelink-SEi12.conf
@@ -1,0 +1,31 @@
+# BeeLink SEi-12
+# See: https://www.techradar.com/reviews/beelink-sei12-mini-pc-review
+#
+# dmi: Board Manufacturer: AZW
+# dmi: Board Product Name: SEi
+# dmi: BIOS Version: ALDER109 12/01/2022
+
+chip "it8613-isa-*"
+  ignore temp3
+  label fan2 "CPU_fan"
+  label fan3 "SYS_fan"
+
+  label temp1 "CPU_temp"
+  set temp1_min 1
+  # Max temperature is 100 C degrees
+  # https://www.intel.com/content/www/us/en/products/sku/226266/intel-core-i51235u-processor-12m-cache-up-to-4-40-ghz-with-ipu/specifications.html
+  # https://www.intel.com/content/www/us/en/products/sku/132222/intel-core-i512450h-processor-12m-cache-up-to-4-40-ghz/specifications.html
+  set temp1_max 100
+
+  label temp2 "SYS_temp"
+  set temp2_min 1
+  # BIOS settings
+  set temp2_max 75
+
+  label in0 "VCore"
+  label in1 "V_SM"
+  ignore in2
+  ignore in4
+  ignore in5
+  ignore in8 # hardcoded Vbat see it87.c
+  ignore intrusion0


### PR DESCRIPTION
Hello!
Mini PC Beelink SEi12 have same chip as Beelink EQ.

Additional info

```shell
mstolyarov@zeon-desktop:~$ cat /sys/class/dmi/id/board_name 
SEi
mstolyarov@zeon-desktop:~$ cat /sys/class/dmi/id/board_vendor 
AZW
mstolyarov@zeon-desktop:~$ cat /sys/class/dmi/id/bios_version 
ALDER109
mstolyarov@zeon-desktop:~$ cat /sys/class/dmi/id/bios_date 
12/01/2022
root@zeon-desktop:~# sensors
it8613-isa-0a30
Adapter: ISA adapter
VCore:       704.00 mV (min =  +0.00 V, max =  +2.81 V)
V_SM:          1.22 V  (min =  +0.00 V, max =  +2.81 V)
3VSB:          1.67 V  (min =  +0.00 V, max =  +5.61 V)
+3.3V:         3.34 V  
CPU_fan:     1912 RPM  (min =    0 RPM)
SYS_fan:     1285 RPM  (min =    0 RPM)
CPU_temp:     +35.0°C  (low  =  +1.0°C, high = +100.0°C)  sensor = thermistor
SYS_temp:     +34.0°C  (low  =  +1.0°C, high = +75.0°C)  sensor = thermistor
```
