### PR TITLE
Add ASUS B350 Plus mobo

### DIFF
--- a/it87.c
+++ b/it87.c
@@ -4618,6 +4618,7 @@ static const struct dmi_system_id it87_dmi_table[] __initconst = {
 	IT87_DMI_MATCH_GBT("X870 GAMING WIFI6", it87_dmi_cb, &it87_acpi_ignore),
 		/* IT8696E*/
 	IT87_DMI_MATCH_VND("nVIDIA", "FN68PT", it87_dmi_cb, &nvidia_fn68pt),
+	IT87_DMI_MATCH_VND("ASUSTeK COMPUTER INC.", "PRIME B350-PLUS", it87_dmi_cb, NULL),
 	{ }
 };
 MODULE_DEVICE_TABLE(dmi, it87_dmi_table);


### PR DESCRIPTION
Most entries pass `it87_acpi_ignore` as `data`, but I'm not sure how to determine if I need to do the same, so I pass NULL. I know the devil is in the details, but it seems to work fine:

```
soren@gallium:~/src/it87$ sensors
k10temp-pci-00c3
Adapter: PCI adapter
Tctl:         +55.0°C  
Tdie:         +35.0°C  

it8655-isa-0290
Adapter: ISA adapter
in0:           1.07 V  (min =  +2.32 V, max =  +1.56 V)  ALARM
in1:           2.52 V  (min =  +2.37 V, max =  +0.68 V)  ALARM
in2:           2.00 V  (min =  +1.34 V, max =  +1.93 V)  ALARM
in3:           2.00 V  (min =  +1.36 V, max =  +1.56 V)  ALARM
in4:           2.00 V  (min =  +2.71 V, max =  +1.35 V)  ALARM
in5:           1.78 V  (min =  +1.04 V, max =  +2.71 V)
in6:           2.00 V  (min =  +0.86 V, max =  +1.02 V)  ALARM
3VSB:          3.33 V  (min =  +1.00 V, max =  +2.40 V)  ALARM
Vbat:          3.29 V  
+3.3V:         3.33 V  
fan1:         394 RPM  (min =   23 RPM)
fan2:         564 RPM  (min =   11 RPM)
fan3:           0 RPM  (min =   10 RPM)  ALARM
temp1:        +35.0°C  (low  = -83.0°C, high =  -3.0°C)  ALARM
temp2:        +35.0°C  (low  = -83.0°C, high = +127.0°C)  sensor = thermistor
temp3:        +39.0°C  (low  = +119.0°C, high = -49.0°C)  ALARM  sensor = thermistor
temp4:        +39.0°C  (low  = -10.0°C, high = +94.0°C)  sensor = thermistor
temp5:        +39.0°C  (low  = +103.0°C, high = +127.0°C)  sensor = thermistor
temp6:        +39.0°C  (low  = +77.0°C, high = -79.0°C)  ALARM  sensor = thermistor
intrusion0:  ALARM
```

