### PR TITLE
Fix deprecated dkms.conf CLEAN

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,6 @@
 PACKAGE_NAME="it87"
 PACKAGE_VERSION=#MODULE_VERSION#
 MAKE[0]="make TARGET=${kernelver}"
-CLEAN="make clean"
 BUILT_MODULE_NAME[0]="it87"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/hwmon"
 AUTOINSTALL="yes"


### PR DESCRIPTION
TLDR: clean was being called to clean the buld_dir only for the next call utilizing build_dir to be a rm -rf of build_dir.

three commits [ [f93a40a](https://github.com/dell/dkms/commit/f93a40aec3b9a5d516d4e8f000023f00dd74550b), [cdad565](https://github.com/dell/dkms/commit/cdad565004349b78b7164fc2195fe70674d2b148), [754f26f](https://github.com/dell/dkms/commit/754f26f93a50348422d991ed9ce2fe9789a65583) ] pushed on April 11, 2025 have deprecated CLEAN as unnecessary for dkms.conf per dkms issue [#502](https://github.com/dell/dkms/issues/502)

fixes: [57](https://github.com/frankcrawford/it87/issues/57)