### PR TITLE
Add force_addr module parameter to override ISA base address

### DIFF
--- a/it87.c
+++ b/it87.c
@@ -220,6 +220,9 @@ static inline void superio_exit(int ioreg, bool noexit)
 static unsigned short force_id[2];
 static unsigned int force_id_cnt;
 
+/* Force ISA base address instead of reading from Super I/O config */
+static unsigned short force_addr;
+
 /* ACPI resource conflicts are ignored if this parameter is set to 1 */
 static bool ignore_resource_conflict;
 
@@ -3152,8 +3155,16 @@ static int __init it87_find(int sioaddr, unsigned short *address,
 		enabled = true;
 		/* and then try again */
 		chip_type = superio_inw(sioaddr, DEVID);
-		if (chip_type == 0xffff)
-			goto exit;
+		if (chip_type == 0xffff) {
+			/* Allow force_id + force_addr to bypass detection */
+			if (force_id[0] && force_addr) {
+				chip_type = force_id[0];
+				pr_info("SIO detection failed, using force_id=0x%04x force_addr=0x%04x\n",
+					force_id[0], force_addr);
+			} else {
+				goto exit;
+			}
+		}
 	}
 
 	if (force_id_cnt == 1) {
@@ -3297,6 +3308,11 @@ static int __init it87_find(int sioaddr, unsigned short *address,
 	}
 
 	*address = superio_inw(sioaddr, IT87_BASE_REG) & ~(IT87_EXTENT - 1);
+	if (force_addr) {
+		pr_info("Forcing base address from 0x%x to 0x%x\n",
+			*address, force_addr);
+		*address = force_addr;
+	}
 	if (*address == 0) {
 		pr_info("Base address not set (chip %s ioreg 0x%x), skipping\n",
 			config->model, sioaddr);
@@ -4712,6 +4728,9 @@ MODULE_DESCRIPTION("IT87xxF/IT86xxE hardware monitoring driver");
 
 module_param_array(force_id, ushort, &force_id_cnt, 0);
 MODULE_PARM_DESC(force_id, "Override one or more detected device ID(s)");
+
+module_param(force_addr, ushort, 0);
+MODULE_PARM_DESC(force_addr, "Force ISA base address (e.g., 0x0a40)");
 
 module_param(ignore_resource_conflict, bool, 0);
 MODULE_PARM_DESC(ignore_resource_conflict, "Ignore ACPI resource conflict");


### PR DESCRIPTION
## Summary

Adds a `force_addr` module parameter that overrides the ISA base address normally read from the Super I/O configuration registers. When combined with `force_id`, this also bypasses SIO chip detection for boards where the SIO port is unreliable.

## Problem

On some motherboards with multiple ITE Super I/O chips, the driver binds to the wrong chip because:

1. The SIO port returns `0xFFFF` (stuck/buggy bridge chip), or
2. The SIO reports the base address of a secondary chip that has no fans connected

This has been reported on Gigabyte X870E boards (see #70) where the IT8696E fan controller at `0x0A40` is unreachable via standard SIO detection, causing 0 RPM readings and non-functional PWM control.

## Solution

New `force_addr` parameter allows specifying the correct base address directly:

```
modprobe it87 force_id=0x8695 force_addr=0x0a40 ignore_resource_conflict=1
```

## Hardware details

**Board:** Gigabyte X870E AORUS MASTER  
**CPU:** AMD Ryzen 9 9950X3D  
**Chip topology:**
- `0x2E` → IT8696E (SIO intermittently stuck due to IT8883 eSPI-to-LPC bridge)
- `0x4E` → IT87952E at base `0x0A60` (no fans wired)
- Actual fan controller: IT8696E at base `0x0A40`

## Testing

Verified on Gigabyte X870E AORUS MASTER:
- Fan tachometer readings work correctly (CPU_FAN, SYS_FAN1, CPU_OPT)
- PWM control functional through hwmon sysfs
- CoolerControl integration confirmed working with fan curve profiles
- DKMS rebuild across kernel updates verified

## Changes

- New `force_addr` module parameter (unsigned short)
- `force_id` + `force_addr` together bypass `0xFFFF` SIO detection failure
- `force_addr` overrides SIO-reported base address before driver binds