### PR TITLE
Add force_activate module parameter for BIOS-inactive chips

### DIFF
--- a/it87.c
+++ b/it87.c
@@ -223,6 +223,9 @@ static unsigned int force_id_cnt;
 /* ACPI resource conflicts are ignored if this parameter is set to 1 */
 static bool ignore_resource_conflict;
 
+/* Force activation of environment controller on chips left inactive by BIOS */
+static bool force_activate;
+
 /* If set the driver uses MMIO to access the chip if supported */
 static bool mmio;
 
@@ -3291,9 +3294,16 @@ static int __init it87_find(int sioaddr, unsigned short *address,
 
 	superio_select(sioaddr, PME);
 	if (!(superio_inb(sioaddr, IT87_ACT_REG) & 0x01)) {
-		pr_info("Device (chip %s ioreg 0x%x) not activated, skipping\n",
-			config->model, sioaddr);
-		goto exit;
+		if (force_activate) {
+			pr_info("Activating chip %s ioreg 0x%x (force_activate=1)\n",
+				config->model, sioaddr);
+			superio_outb(sioaddr, IT87_ACT_REG,
+				     superio_inb(sioaddr, IT87_ACT_REG) | 0x01);
+		} else {
+			pr_info("Device (chip %s ioreg 0x%x) not activated, skipping\n",
+				config->model, sioaddr);
+			goto exit;
+		}
 	}
 
 	*address = superio_inw(sioaddr, IT87_BASE_REG) & ~(IT87_EXTENT - 1);
@@ -4715,6 +4725,9 @@ MODULE_PARM_DESC(force_id, "Override one or more detected device ID(s)");
 
 module_param(ignore_resource_conflict, bool, 0);
 MODULE_PARM_DESC(ignore_resource_conflict, "Ignore ACPI resource conflict");
+
+module_param(force_activate, bool, 0);
+MODULE_PARM_DESC(force_activate, "Force activation of chips the BIOS left disabled");
 
 module_param(mmio, bool, 0);
 MODULE_PARM_DESC(mmio, "Use MMIO if available");


### PR DESCRIPTION
## Problem

Some Gigabyte motherboards with dual ITE Super I/O chips leave one chip's
environment controller inactive in the BIOS. The driver detects the chip but
skips it with "Device not activated, skipping" because the activation register
(0x30) bit 0 is not set.

This affects at least:
- Gigabyte X870E AORUS MASTER (IT87952E + IT8696E)
- Gigabyte X870E AORUS PRO (per #70)

On the X870E AORUS MASTER, the IT8696E chip controls CPU_FAN, SYS_FAN1-3, and
CPU_OPT fan headers. Without activating it, these fans are invisible to Linux
while the BIOS Smart Fan 6 can see and control them all.

## Solution

Add a `force_activate` module parameter (default off) that writes the activation
bit to enable the environment controller on chips the BIOS left disabled.

```
modprobe it87 ignore_resource_conflict=1 force_activate=1
```

## Testing

Tested on Gigabyte X870E AORUS MASTER (BIOS F3c) with Fedora 43, kernel 6.18.9:

**Before** (only IT87952E detected, 3 fans):
```
fan1:  1046 RPM   # SYS_FAN4 (120mm)
fan2:  1051 RPM   # FAN5_PUMP (120mm)
fan3:  1062 RPM   # FAN6_PUMP (120mm)
```

**After** (IT8696E also activated, 5 additional fans):
```
# IT8696E
fan1:  1403 RPM   # CPU_FAN (CPU cooler)
fan2:  1112 RPM   # SYS_FAN1 (80mm)
fan3:  1106 RPM   # SYS_FAN2 (80mm)
fan4:     0 RPM   # SYS_FAN3 (unused)
fan5:  3154 RPM   # CPU_OPT (DDR Wind Blade)

# IT87952E
fan1:  1046 RPM   # SYS_FAN4 (120mm)
fan2:  1051 RPM   # FAN5_PUMP (120mm)
fan3:  1062 RPM   # FAN6_PUMP (120mm)
```

dmesg output with the fix:
```
it87: Found IT8696E chip at 0xa40, revision 0
it87: Beeping is supported
it87: Activating chip IT8696E ioreg 0x4e (force_activate=1)
it87: Ignoring expected ACPI resource conflict
it87: Found IT87952E chip at 0xa60, revision 1
it87: Beeping is supported
```