### PR TITLE
Add Sensors Config for UGREEN DXP6800 Pro sensors

### DIFF
--- a/Sensors configs/UGreen-DXP6800-Pro.conf
+++ b/Sensors configs/UGreen-DXP6800-Pro.conf
@@ -1,7 +1,6 @@
 ## Manufacturer: UGREEN
 ## Product Name: DXP6800 Pro
 #########################################
-
 chip "it8613-*"
 
     ignore temp3
@@ -29,10 +28,16 @@ chip "it8613-*"
     set temp2_max 100
 
     set in1_min 1.00
-    set in1_max 1.25
+    set in1_max 1.50
+
+    set in2_min 1.80
+    set in2_max 2.20
+
+    set in4_min 1.80
+    set in4_max 2.20
 
     set in5_min 1.80
     set in5_max 2.20
 
-    set in7_min 3.10
+    set in7_min 3.00
     set in7_max 3.50

--- a/Sensors configs/UGreen-DXP6800-Pro.conf
+++ b/Sensors configs/UGreen-DXP6800-Pro.conf
@@ -1,0 +1,38 @@
+## Manufacturer: UGREEN
+## Product Name: DXP6800 Pro
+#########################################
+
+chip "it8613-*"
+
+    ignore temp3
+    ignore intrusion0
+    ignore pwm2
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+
+    label fan2 "CPU Fan"
+    label fan3 "Case Fan 1"
+    label fan4 "Case Fan 2"
+    label temp1 "CPU Temp (PECI)"
+    label temp2 "Case Temp"
+    label in0 "CPU Voltage"
+    label in1 "Memory Voltage"
+
+    set fan2_min 300
+    set fan3_min 300
+    set fan4_min 300
+
+    set temp1_min 5
+    set temp1_max 100
+    set temp2_min 5
+    set temp2_max 100
+
+    set in1_min 1.00
+    set in1_max 1.25
+
+    set in5_min 1.80
+    set in5_max 2.20
+
+    set in7_min 3.10
+    set in7_max 3.50

--- a/Sensors configs/UGreen-DXP6800-Pro.conf
+++ b/Sensors configs/UGreen-DXP6800-Pro.conf
@@ -1,5 +1,8 @@
 ## Manufacturer: UGREEN
 ## Product Name: DXP6800 Pro
+##
+## provided by github.com/telnetdoogie
+## telnetdoogie@gmail.com
 #########################################
 chip "it8613-*"
 


### PR DESCRIPTION
Sample output:

```
it8613-isa-0a30
Adapter: ISA adapter
CPU Voltage:     682.00 mV (min =  +0.00 V, max =  +2.07 V)
Memory Voltage:    1.13 V  (min =  +1.00 V, max =  +1.50 V)
in2:               2.06 V  (min =  +1.80 V, max =  +2.20 V)
in4:               2.01 V  (min =  +1.80 V, max =  +2.20 V)
in5:               2.04 V  (min =  +1.80 V, max =  +2.20 V)
3VSB:              3.32 V  (min =  +2.99 V, max =  +3.50 V)
Vbat:              2.77 V
+3.3V:             3.37 V
CPU Fan:         2896 RPM  (min =  300 RPM)
Case Fan 1:       972 RPM  (min =  300 RPM)
Case Fan 2:       971 RPM  (min =  300 RPM)
CPU Temp (PECI):  +46.0°C  (low  =  +5.0°C, high = +100.0°C)  sensor = Intel PECI
Case Temp:        +35.0°C  (low  =  +5.0°C, high = +100.0°C)  sensor = thermal diode
```