### PR TITLE
it87: add force_pwm parameter for active-low boards

### DIFF
--- a/README
+++ b/README
@@ -60,6 +60,15 @@ Module Parameters
   misconfigured by BIOS - PWM values would be inverted. This option tries
   to fix this. Please contact your BIOS manufacturer and ask him for fix.
 
+* force_pwm
+
+  Counterpart to fix_pwm_polarity for boards that need active low.
+  Some units (notably certain NAS systems) deliberately leave the fans
+  off with active-low polarity, which trips the broken-BIOS check
+  even if the configuration is fine. force_pwm enables the PWM interface
+  while keeping the BIOS active-low polarity. Misapplying it inverts fan 
+  control, so it is DANGEROUS and off by by default.
+
 * force_id [short, short]
 
   Force multiple chip ID to specified value, separated by `,'.
@@ -128,6 +137,42 @@ Device Support
  *            IT8792E  Super I/O chip w/LPC interface
  *            IT87952E  Super I/O chip w/LPC interface
  *            Sis950   A clone of the IT8705F
+
+Fan control disabled: "Detected broken BIOS defaults"
+-----------------------------------------------------
+
+If `dmesg` shows a line like:
+
+    it87 it87.656: Detected broken BIOS defaults, disabling PWM interface
+
+and no `pwmN` files appear under the chip's `hwmon` directory (you can read
+fan RPM but cannot set fan speed), then run `test_pwm_polarity.sh` 
+(included in this repo) as root:
+
+    sudo ./test_pwm_polarity.sh
+
+It loads the driver with `force_pwm`, drives the fan to full and to off, reads
+the tachometer, and reports whether you want `force_pwm`, `fix_pwm_polarity`,
+or that PWM cannot be made to work on your board. If your board needs extra
+load-time parameters (for example `ignore_resource_conflict=1`), pass them
+through with the `IT87_PARAMS` environment variable:
+
+    sudo IT87_PARAMS="ignore_resource_conflict=1" ./test_pwm_polarity.sh
+
+The script changes nothing permanent and restores the fan to its hardware
+default on exit. If you run a fan-control daemon (fancontrol or your own
+service), stop it first so it does not fight the script for the pwm.
+
+Once you know which parameter your board needs, set it so the module loads
+that way every boot. Create `/etc/modprobe.d/it87.conf`:
+
+    options it87 force_pwm=1
+
+Substitute `fix_pwm_polarity=1` if that was the result, and append any other
+parameters your board requires, for example:
+
+    options it87 ignore_resource_conflict=1 force_pwm=1
+
 
 TODOS:
 ------

--- a/it87.c
+++ b/it87.c
@@ -317,6 +317,7 @@ static bool update_vbat;
 
 /* Not all BIOSes properly configure the PWM registers */
 static bool fix_pwm_polarity;
+static bool force_pwm;
 
 /* Many IT87 constants specified below */
 
@@ -5411,6 +5412,25 @@ static int it87_check_pwm(struct device *dev)
 	 */
 	int tmp = data->read(data, IT87_REG_FAN_CTL);
 
+	/*
+	 * Counterpart to fix_pwm_polarity for boards that need active-low.
+	 * Some units (notably certain NAS systems) deliberately leave the fans
+	 * off with active-low polarity, which trips the broken-BIOS check below
+	 * even though the configuration is fine; on those boards fix_pwm_polarity
+	 * would invert fan control. force_pwm instead enables the PWM interface
+	 * while keeping the BIOS active-low polarity. It runs before the check so
+	 * it forces a deterministic state regardless of current register
+	 * contents, which the userspace detection helper in the README relies on.
+	 * Misapplying it inverts fan control, so it is DANGEROUS and off by
+	 * default.
+	 */
+	if (force_pwm) {
+		dev_info(dev, "Enabling PWM, forcing BIOS active-low polarity\n");
+		/* clear polarity bit (active-low), set the 3 fan main-control bits */
+		data->write(data, IT87_REG_FAN_CTL, (tmp & ~0x80) | 0x07);
+		return 1;
+	}
+
 	if ((tmp & 0x87) == 0) {
 		if (fix_pwm_polarity) {
 			/*
@@ -5569,7 +5589,7 @@ static int it87_probe(struct platform_device *pdev)
 
 	enable_pwm_interface = it87_check_pwm(dev);
 	if (!enable_pwm_interface)
-		dev_info(dev, "Detected broken BIOS defaults, disabling PWM interface\n");
+		dev_info(dev, "Detected broken BIOS defaults, disabling PWM interface (see fix_pwm_polarity and force_pwm parameters)\n");
 
 	if (has_scaling(data))
 	{
@@ -6129,6 +6149,9 @@ MODULE_PARM_DESC(update_vbat, "Update vbat if set else return powerup value");
 module_param(fix_pwm_polarity, bool, 0);
 MODULE_PARM_DESC(fix_pwm_polarity,
 		 "Force PWM polarity to active high (DANGEROUS)");
+module_param(force_pwm, bool, 0);
+MODULE_PARM_DESC(force_pwm,
+		 "Enable PWM interface keeping BIOS active-low polarity (DANGEROUS)");
 
 MODULE_LICENSE("GPL");
 MODULE_VERSION(IT87_DRIVER_VERSION);

--- a/test_pwm_polarity.sh
+++ b/test_pwm_polarity.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# test_pwm_polarity.sh
+#
+# For IT87-family boards that hit:
+#     it87 ...: Detected broken BIOS defaults, disabling PWM interface
+#
+# This tells you which module parameter restores working fan control:
+#     force_pwm=1          (board wants active-low polarity)
+#     fix_pwm_polarity=1   (board wants active-high polarity)
+#     or that PWM is genuinely unusable.
+#
+# How it works: it loads the driver with force_pwm=1, which forces a known
+# active-low state and enables the PWM interface, then drives the fan to full
+# and to off and watches the tachometer. If the fan responds in the normal
+# direction, active-low is correct. If it responds inverted, the board wants
+# active-high, so fix_pwm_polarity is the right knob. No clear response means
+# there's no usable tach on that channel or PWM can't be made to work.
+#
+# SAFE TO RUN: it spins the fan up and down for a few seconds and reloads the
+# it87 module. It changes NO persistent configuration. If you run a fan-control
+# daemon (fancontrol, or your own service), stop it first so it does not fight
+# this script for the pwm, then restart it after.
+#
+# Boards that need extra load-time params (e.g. ignore_resource_conflict=1)
+# can pass them via the IT87_PARAMS environment variable.
+#
+# Usage:
+#   sudo ./test_pwm_polarity.sh [-y]
+#   sudo IT87_PARAMS="ignore_resource_conflict=1" ./test_pwm_polarity.sh
+
+set -uo pipefail
+
+SETTLE=5                             # seconds to wait after a pwm change before reading the tach
+THRESH=200                           # min RPM gap to call a direction with confidence
+EXTRA_PARAMS="${IT87_PARAMS:-}"      # extra modprobe params for this board
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+[ "$(id -u)" -eq 0 ] || die "must run as root (it loads modules and writes pwm)"
+
+if [ "${1:-}" != "-y" ]; then
+    echo "This will reload the it87 module and briefly spin your fan to full and to off."
+    echo "Stop any fan-control daemon (fancontrol, custom service) before continuing."
+    read -r -p "Continue? [y/N] " ans
+    case "$ans" in [yY]*) ;; *) echo "aborted."; exit 0 ;; esac
+fi
+
+echo ">> Reloading it87 with force_pwm=1 (forces a known active-low state)..."
+modprobe -r it87 2>/dev/null
+# shellcheck disable=SC2086
+modprobe it87 force_pwm=1 $EXTRA_PARAMS || die "could not load it87 with force_pwm=1"
+
+# From here on, restore a safe state on any exit: drop force_pwm so the board's
+# own hardware default takes the fan back (the safe "fan just runs" condition).
+restore() {
+    echo ">> Restoring fan to hardware default (reloading without force_pwm)."
+    echo "   Apply your chosen parameter and reboot to make control permanent."
+    modprobe -r it87 2>/dev/null
+    # shellcheck disable=SC2086
+    modprobe it87 $EXTRA_PARAMS 2>/dev/null || true
+}
+trap restore EXIT
+
+# Locate the it87 hwmon by name.
+HW=""
+for d in /sys/class/hwmon/hwmon*; do
+    n=$(cat "$d/name" 2>/dev/null) || continue
+    case "$n" in it86*|it87*) HW="$d"; break ;; esac
+done
+[ -n "$HW" ] || die "no it87/it86xx hwmon found (is the chip detected?)"
+echo ">> Using $HW ($(cat "$HW/name"))"
+
+# Pick the first pwm channel that has a matching fan tachometer.
+PWM=""; FAN=""
+for p in "$HW"/pwm[0-9]*; do
+    [ -e "$p" ] || continue
+    b="${p##*/}"
+    case "$b" in *_*) continue ;; esac     # skip pwmN_enable, pwmN_freq, ...
+    num="${b#pwm}"
+    if [ -e "$HW/fan${num}_input" ]; then
+        PWM="$p"; FAN="$HW/fan${num}_input"; break
+    fi
+done
+[ -n "$PWM" ] || die "no controllable pwm channel with a tach was found; PWM may not be enabled"
+ENABLE="${PWM}_enable"
+echo ">> Testing $(basename "$PWM") against $(basename "$FAN")"
+
+read_rpm() {                             # read_rpm <pwm_value> -> settled RPM
+    [ -w "$ENABLE" ] && echo 1 > "$ENABLE" 2>/dev/null   # manual mode
+    echo "$1" > "$PWM" 2>/dev/null
+    sleep "$SETTLE"
+    cat "$FAN" 2>/dev/null || echo 0
+}
+
+echo ">> Driving pwm=255 ..."
+HIGH=$(read_rpm 255); echo "   tach at pwm=255: ${HIGH} RPM"
+echo ">> Driving pwm=0 ..."
+LOW=$(read_rpm 0);    echo "   tach at pwm=0:   ${LOW} RPM"
+
+echo
+if [ "$HIGH" -gt "$((LOW + THRESH))" ]; then
+    echo "RESULT: pwm=255 spins the fan, pwm=0 stops it. Normal direction."
+    echo "        This board wants ACTIVE-LOW.  Use:  force_pwm=1"
+elif [ "$LOW" -gt "$((HIGH + THRESH))" ]; then
+    echo "RESULT: pwm=0 spins the fan, pwm=255 stops it. Inverted."
+    echo "        This board wants ACTIVE-HIGH. Use:  fix_pwm_polarity=1"
+else
+    echo "RESULT: the fan did not respond clearly to either value (high=${HIGH}, low=${LOW})."
+    echo "        Either there is no tachometer on this channel, or PWM cannot be"
+    echo "        made to work on this board. Software fan control will not function."
+fi


### PR DESCRIPTION
I ran into this on an Asustor Lockerstor NAS (ITE IT8625E). Loaded normally, the driver logs "Detected broken BIOS defaults, disabling PWM interface" and I get fan RPM readings but no pwm control at all. The board isn't actually broken, though. It just ships with the fans off and active-low polarity, which is the exact pattern that check is built to treat as a bad BIOS.

The existing `fix_pwm_polarity` gets PWM back, but it forces active-high, and on this board that runs everything backwards: pwm=255 stops the fan and pwm=0 runs it full blast. I figured I *could* write a backwards fan curve to make it work, but I decided to try and fix it right instead. 

This adds `force_pwm`, basically the active-low version of `fix_pwm_polarity`: it re-enables the interface but keeps the default settings otherwise. With it, pwm runs the right way on my board (255 gives ~2600 RPM, 0 stops the fan). Like `fix_pwm_polarity`, it's off by default and does nothing unless you explicitly pass it, so it shouldn't affect anyone who doesn't set it.

I was thinking that ideally there would be a safe way to determine what the right  parameter is for a user who gets the same "Detected broken BIOS defaults, disabling PWM interface"  message, but isn't sure what they need, so  I also added `test_pwm_polarity.sh`, which loads `force_pwm`, spins the fan up and down, watches the tach, and tells you which parameter you need (or that PWM can't be made to work, if neither option gets you functioning fans). It should keep a naive user from just trying parameters and getting the polarity wrong or a broken system. 

One thing I wanted to mention: I put the force_pwm check before the broken-defaults check rather than inside it, so it forces a known state no matter what's already in the register, which is what lets the test script be reliable. If you'd rather move it inside the branch next to fix_pwm_polarity, I can adjust that. 

Tested on my Lockerstor (IT8625E, kernel 6.17): modinfo shows the parameter, the script reports active-low, and the fan runs in the correct direction. Survives reboot. 