### PR TITLE
it87: enable manual PWM on IT8689E/IT8696E (FEAT_BRIDGE_MMIO)

### DIFF
--- a/it87.c
+++ b/it87.c
@@ -3230,10 +3230,21 @@ static ssize_t set_pwm_enable(struct device *dev, struct device_attribute *attr,
 		if (has_newer_autopwm(data)) {
 			ctrl = temp_map_to_reg(data, nr,
 					       data->pwm_temp_map[nr]);
-			if (val == 1)
-				ctrl &= 0x7f;
-			else
+			if (val == 1) {
+				/*
+				 * it8689/it8696/it8698 (FEAT_BRIDGE_MMIO) keep
+				 * running the temp-map "vector" controller in
+				 * manual mode unless every map-select bit is set,
+				 * so they ignore the manual duty written to the
+				 * EXT (PWM_DUTY) register. Writing 0x7f to the base
+				 * PWM control register releases that override (this
+				 * is what LibreHardwareMonitor does on Windows).
+				 * Other newer chips keep their existing behavior.
+				 */
+				ctrl = data->mmio_bridge ? 0x7f : (ctrl & 0x7f);
+			} else {
 				ctrl |= 0x80;
+			}
 		} else {
 			ctrl = (val == 1 ? data->pwm_duty[nr] : 0x80);
 		}


### PR DESCRIPTION
## Summary

Enable software PWM control of the fans on the **IT8689E / IT8696E** (the
`FEAT_BRIDGE_MMIO` + newer-autopwm chips on recent Gigabyte boards). Today, on
these chips, manual mode is accepted but the duty has no effect — the symptom
tracked in #96.

## Problem

On a Gigabyte **X870E AORUS PRO ICE** (IT8696E rev 0 + IT87952E rev 1, MMIO
backend, `mmio=on`), with the current driver:

- `pwmN_enable = 1` succeeds and the base reg shows manual,
- writing the duty to the EXT `PWM_DUTY` register succeeds,
- **but fan RPM does not change** — the chip keeps following its temp-map
  ("vector") controller.

This matches #96 (IT8689E) and several other reports for 8xx Gigabyte boards.
The GB EC fan controller (H2RAM `0x947`) is *not* the cause here — on this board
it already reads `0x00` (disabled) and the fans are still overridden by the
chip's own vector controller.

## Root cause / reference

The base PWM control register's low bits select the temp map. These chips only
relinquish the vector controller in manual mode when **all map-select bits are
set**. The current code writes `temp_map_to_reg(...) & 0x7f` (a specific map),
so the vector controller stays active and ignores the EXT duty.

LibreHardwareMonitor does exactly this on Windows — in `IT87XX.SetControl()` for
the IT8689E it writes **`0x7F` to the base reg** and then the duty to the EXT
reg (`FAN_PWM_CTRL_EXT_REG = {0x63,0x6b,0x73,0x7b,0xa3,0xab}`, which this driver
already knows as `IT87_REG_PWM_DUTY[]`).

## Fix

In `set_pwm_enable()`, for `FEAT_BRIDGE_MMIO` chips in manual mode, write `0x7f`
to the base PWM control register instead of the temp-map value. Non-bridge
newer-autopwm chips (e.g. IT87952E, which works via the SmartFan-global path)
are unchanged.

```c
if (val == 1)
        ctrl = data->mmio_bridge ? 0x7f : (ctrl & 0x7f);
else
        ctrl |= 0x80;
```

## Testing

Gigabyte X870E AORUS PRO ICE, kernel 6.17, MMIO backend. Driving each it8696
channel through the **normal hwmon sysfs** (`pwmN_enable=1`, then `pwmN`):

| header (it8696) | before | after — duty 60 → 255 |
|---|---|---|
| CPU_FAN  (pwm1) | no change | 546 → 1161 rpm |
| SYS_FAN1 (pwm2) | no change | 686 → 1073 rpm |
| SYS_FAN3 (pwm4) | no change | 920 → 2454 rpm |

The IT87952E headers (already controllable) are unaffected. `CPU_OPT` (pwm5) is
an AIO pump and was left in automatic. Setting `pwmN_enable=2` restores
automatic control cleanly. fancontrol now drives all of these correctly.

## Notes / questions

- This is empirical: `0x7f` reproduces LHM's behaviour, but I haven't fully
  reverse-engineered the exact map-select bit semantics. Happy to dig further.
- Gated on `data->mmio_bridge` as a proxy for the affected chips — you may
  prefer a dedicated feature flag or a narrower condition.
- Duty values below ~60 behaved non-monotonically on my fans (likely fan-side),
  so I keep a floor in userspace; not relevant to the driver change.
- I saw #96 mentions a larger rework in progress — if this is already covered
  there, feel free to fold it in or close this; just wanted to share a minimal,
  tested fix and the LHM cross-reference.
