### PR TITLE
Remove MMIO support for IT8665E. Fixes #106.

### DIFF
--- a/it87.c
+++ b/it87.c
@@ -830,7 +830,7 @@ static const struct it87_devices it87_devices[] = {
 		.features = FEAT_NEWER_AUTOPWM | FEAT_16BIT_FANS
 		  | FEAT_AVCC3 | FEAT_NEW_TEMPMAP
 		  | FEAT_10_9MV_ADC | FEAT_IN7_INTERNAL | FEAT_BANK_SEL
-		  | FEAT_SIX_TEMP | FEAT_MMIO,
+		  | FEAT_SIX_TEMP,
 		.num_temp_limit = 6,
 		.num_temp_offset = 6,
 		.num_temp_map = 6,

--- a/it87.c
+++ b/it87.c
@@ -842,7 +842,7 @@ static const struct it87_devices it87_devices[] = {
 		.features = FEAT_NEWER_AUTOPWM | FEAT_16BIT_FANS
 		  | FEAT_AVCC3 | FEAT_NEW_TEMPMAP
 		  | FEAT_10_9MV_ADC | FEAT_IN7_INTERNAL | FEAT_SIX_FANS
-		  | FEAT_SIX_PWM | FEAT_BANK_SEL | FEAT_MMIO | FEAT_SIX_TEMP,
+		  | FEAT_SIX_PWM | FEAT_BANK_SEL | FEAT_SIX_TEMP,
 		.num_temp_limit = 6,
 		.num_temp_offset = 6,
 		.num_temp_map = 6,


### PR DESCRIPTION
Hi,

I started experiencing strange behavior when setting PWM values on my X470-Pro board. I came across #106 which described the exact issue and noted that adding `mmio=off` does indeed fix the issue.

Persuant to Tsunami's comment there, this PR simply removes the MMIO flag from the IT8665E's feature set, so that the `mmio=off` module parameter is no longer needed.

Apologies if I am misunderstanding or if this is not wanted as a long-term change.