### PR TITLE
hwmon: it87: write updated tachometer enable mask

### DIFF
--- a/it87.c
+++ b/it87.c
@@ -5272,7 +5272,7 @@ static void it87_check_tachometers_reset(struct platform_device *pdev)
 	if ((fan_main_ctrl & mask) == 0) {
 		/* Enable all fan tachometers */
 		fan_main_ctrl |= mask;
-		data->write(data, IT87_REG_FAN_MAIN_CTRL, data->fan_main_ctrl);
+		data->write(data, IT87_REG_FAN_MAIN_CTRL, fan_main_ctrl);
 	}
 }
 


### PR DESCRIPTION
## Summary

Write the locally updated `fan_main_ctrl` value after enabling missing
tachometer bits.

## Root cause

`it87_check_tachometers_reset()` reads the live register into a local variable
and adds the required tachometer-enable mask, but the current out-of-tree
driver writes the cached `data->fan_main_ctrl` value instead. That can discard
the mask the function just computed.

This change also restores the behavior used by the current mainline Linux
driver:
https://github.com/torvalds/linux/blob/master/drivers/hwmon/it87.c

## Impact

If firmware or a power transition clears the tachometer-enable bits, the
driver now writes the corrected live value and preserves its other bits.

## Validation

- `git diff --check` passes.
- The external module builds against Ubuntu kernel `6.8.0-137-generic`
  headers on a Gigabyte B760 system.
- This validation was build-only; the installed module was not replaced or
  reloaded.
