### PR TITLE
Add X870E AORUS ELITE WIFI7 DMI support

### DIFF
--- a/it87.c
+++ b/it87.c
@@ -7081,6 +7081,9 @@ static const struct dmi_system_id it87_dmi_table[] __initconst = {
 	IT87_DMI_MATCH_GBT("X870 AORUS ELITE WIFI7 ICE", it87_dmi_cb,
 			   &it87_acpi_ignore),
 		/* IT8696E */
+	IT87_DMI_MATCH_GBT("X870E AORUS ELITE WIFI7", it87_dmi_cb,
+			   &it87_acpi_ignore),
+		/* IT8696E */
 	IT87_DMI_MATCH_GBT("X870 GAMING WIFI6", it87_dmi_cb,
 			   &it87_acpi_ignore),
 		/* IT8696E */


### PR DESCRIPTION
## Summary

- add the exact `X870E AORUS ELITE WIFI7` DMI match
- apply the existing Gigabyte ACPI-resource handling for this board

The existing table contains `X870 AORUS ELITE WIFI7`, but the tested board reports `X870E AORUS ELITE WIFI7`. The mismatch prevents the module DMI alias from matching at boot.

Board-specific lm-sensors labels are deliberately not included because their channel mappings have not been verified header by header.

## Hardware validation

Tested on:

- Gigabyte X870E AORUS ELITE WIFI7
- BIOS F9
- AMD Ryzen 9 7900X
- Pop!_OS / kernel 7.1.5-76070105-generic

`sensors-detect` reports chip ID `0x8696`. The current driver built and loaded without `force_id` or `ignore_resource_conflict`; it selected the IT8696E at `0xa40` using MMIO and exposed six live fan inputs.

## Validation

- `make clean && make -j$(nproc)`
- confirmed the built module contains `dmi*:...:rn*X870EAORUSELITEWIFI7*:`
- `git diff --check`