### PR TITLE
fix sensors.d installer to use correct directory.

### DIFF
--- a/Sensors configs/Gigabyte/install-sensorsd.sh
+++ b/Sensors configs/Gigabyte/install-sensorsd.sh
@@ -2,7 +2,7 @@
 set -eu
 
 SRC_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-CATALOG_DIR="$SRC_DIR/catalog"
+CATALOG_DIR="$SRC_DIR/configs"
 DEST_DIR="/etc/sensors.d"
 VENDOR="auto"
 X299_VARIANT="auto"


### PR DESCRIPTION
@frankcrawford Fixes installer source directory. It slipped through my testing. The installer script will now use the correct one.