### PR TITLE
fix split entries in sensors.d configs and ignore sensors that don't apply.

### DIFF
--- a/Sensors configs/Gigabyte/configs/gigabyte-it87-amd.conf
+++ b/Sensors configs/Gigabyte/configs/gigabyte-it87-amd.conf
@@ -53,6 +53,16 @@ chip "it8686_10020507-*" "it8686_12020507-*" "it8686_30020507-*" "it8686_3102050
     label fan2    "SYS_FAN1"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x10030507
 # Motherboards:
@@ -93,6 +103,14 @@ chip "it8686_10030507-*" "it8686_30030507-*" "it8686_31030507-*" "it8689_3203050
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x10040607
 # Motherboards:
@@ -135,6 +153,11 @@ chip "it8686_10040607-*" "it8686_30040607-*" "it8686_31040607-*" "it8689_3204060
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan5
+    ignore fan6
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x10050607
 # Motherboards:
@@ -171,6 +194,9 @@ chip "it8686_10050607-*" "it8686_11050607-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3_PUMP"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x1008090B
 # Motherboards:
@@ -207,6 +233,35 @@ chip "it8686_1008090b-*" "it8686_3008090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x1008090B
+# Motherboards:
+#   GA-AX370-GAMING 5
+#   GA-AX370-GAMING K7
+chip "it8792_1008090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "Chipset Core"
+    label in4     "CPU VDD18"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x2008090D
 # Motherboards:
@@ -239,6 +294,37 @@ chip "it8686_2008090d-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x2008090D
+# Motherboards:
+#   X399 AORUS GAMING 7
+#   X399 AORUS PRO
+chip "it8792_2008090d-*"
+    label in0     "CPU VCORE SIO"
+    label in1     "DDRVPP CH(A/B)"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "Chipset Core"
+    label in3     "5VSB"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VDD18"
+    label in5     "DDRVPP CH(C/D)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x2108090D
 # Motherboards:
@@ -274,6 +360,40 @@ chip "it8686_2108090d-*" "it8686_2208090d-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x2108090D
+# Motherboards:
+#   X399 AORUS XTREME
+#   X399 DESIGNARE EX
+# SIV 0x2208090D
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it8792_2108090d-*" "it8792_2208090d-*"
+    label in0     "CPU VCORE SIO"
+    label in1     "DDRVPP CH(A/B)"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "Chipset Core"
+    label in3     "5VSB"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VDD18"
+    label in5     "DDRVPP CH(C/D)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX16_2"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x30050607
 # Motherboards:
@@ -319,6 +439,85 @@ chip "it8686_30050607-*" "it8686_30080907-*" "it8686_31050607-*" "it8686_3108090
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x30080907
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it8792_30080907-*"
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP1"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x3008090B
+# Motherboards:
+#   X470 AORUS GAMING 7 WIFI
+#   X470 AORUS GAMING 7 WIFI-50
+chip "it8792_3008090b-*"
+    label in0     "DDRVTT CH(A/B)"
+    label in1     "Chipset Core"
+    label in3     "CPU VDD18"
+    label in4     "Chipset Core 2.5V"
+    compute in4   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in2
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x3108090B
+# Motherboards:
+#   X470 AORUS GAMING 5 WIFI
+#   X470 AORUS ULTRA GAMING
+chip "it8792_3108090b-*"
+    label in0     "DDRVTT CH(A/B)"
+    label in1     "Chipset Core"
+    label in3     "CPU VDD18"
+    label in4     "Chipset Core 2.5V"
+    compute in4   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP1"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in2
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x40030407
 # Motherboards:
@@ -344,6 +543,15 @@ chip "it8688_40030407-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "PCH_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp2
+    ignore temp4
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x40050607
 # Motherboards:
@@ -378,6 +586,9 @@ chip "it8688_40050607-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "PCH_FAN"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x4008090A
 # Motherboards:
@@ -423,6 +634,35 @@ chip "it8688_4008090a-*" "it8688_4108090b-*" "it8688_6008090b-*" "it8688_6108090
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x4008090A
+# Motherboards:
+#   X570 AORUS XTREME
+# SIV 0x8108090A
+# Motherboards:
+#   X570S AERO G
+chip "it8792_4008090a-*" "it87952_8108090a-*"
+    label in2     "Chipset Core"
+    label in4     "CPU VDD18"
+    label in5     "PM_CLDO12"
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x4008090B
 # Motherboards:
@@ -462,6 +702,64 @@ chip "it8688_4008090b-*" "it8688_4208090b-*" "it8688_4308090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "PCH_FAN"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x4008090B
+# Motherboards:
+#   X570 AORUS PRO
+#   X570 AORUS PRO WIFI
+#   X570 AORUS ULTRA
+chip "it8792_4008090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "Chipset Core"
+    label in4     "CPU VDD18"
+    label in5     "PM_CLDO12"
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x4108090B
+# Motherboards:
+#   X570 AORUS XTREME
+# SIV 0x4208090B
+# Motherboards:
+#   X570 AORUS MASTER
+# SIV 0x4308090B
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it8792_4108090b-*" "it8792_4208090b-*" "it8792_4308090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "Chipset Core"
+    label in4     "CPU VDD18"
+    label in5     "PM_CLDO12"
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x5008090B
 # Motherboards:
@@ -497,6 +795,61 @@ chip "it8688_5008090b-*" "it8688_5108090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "PCH_FAN"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x5008090B
+# Motherboards:
+#   TRX40 AORUS PRO WIFI
+#   TRX40 DESIGNARE
+chip "it8792_5008090b-*"
+    label in1     "DDRVPP CH(A/B)"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "Chipset Core"
+    label in4     "CPU VDD18"
+    label in5     "DDRVPP CH(C/D)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX16_2"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5A_PUMP"
+    label fan2    "SYS_FAN6A_PUMP"
+    label fan3    "MOS_FAN"
+    label pwm1    "SYS_FAN5A_PUMP/SYS_FAN5B_PUMP"
+    label pwm2    "SYS_FAN6A_PUMP/SYS_FAN6B_PUMP"
+    label pwm3    "MOS_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x5108090B
+# Motherboards:
+#   TRX40 AORUS MASTER
+chip "it8792_5108090b-*"
+    label in1     "DDRVPP CH(A/B)"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "Chipset Core"
+    label in4     "CPU VDD18"
+    label in5     "DDRVPP CH(C/D)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX16_2"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5A_PUMP"
+    label fan2    "SYS_FAN6A_PUMP"
+    label fan3    "MOS_FAN"
+    label pwm1    "SYS_FAN5A_PUMP/SYS_FAN5B_PUMP"
+    label pwm2    "SYS_FAN6A_PUMP/SYS_FAN6B_PUMP"
+    label pwm3    "MOS_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x5208090B
 # Motherboards:
@@ -528,6 +881,34 @@ chip "it8688_5208090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "PCH_FAN"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x5208090B
+# Motherboards:
+#   TRX40 AORUS XTREME
+chip "it8792_5208090b-*"
+    label in1     "DDRVPP CH(A/B)"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "Chipset Core"
+    label in4     "CPU VDD18"
+    label in5     "DDRVPP CH(C/D)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX16_2"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5A_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5A_PUMP/SYS_FAN5B_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x5308090A
 # Motherboards:
@@ -559,6 +940,34 @@ chip "it8688_5308090a-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x5308090A
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it8792_5308090a-*"
+    label in1     "DDRVPP CH(A/B)"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "Chipset Core"
+    label in5     "DDRVPP CH(C/D)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX16_2"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in4
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x60030507
 # Motherboards:
@@ -591,7 +1000,7 @@ chip "it8688_5308090a-*"
 # SIV 0x71030507
 # Motherboards:
 #   A520M H ARGB
-chip "it8688_60030507-*" "it8688_70030507-*" "it8689_61030507-*" "it8689_71030507-*"
+chip "it8688_60030507-*" "it8689_61030507-*" "it8688_70030507-*" "it8689_71030507-*"
     label in0     "CPU Vcore"
     label in1     "+3.3V"
     compute in1   @ * 1.649, @ / 1.649
@@ -613,6 +1022,14 @@ chip "it8688_60030507-*" "it8688_70030507-*" "it8689_61030507-*" "it8689_7103050
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x60050607
 # Motherboards:
@@ -641,7 +1058,7 @@ chip "it8688_60030507-*" "it8688_70030507-*" "it8689_61030507-*" "it8689_7103050
 # SIV 0x71050607
 # Motherboards:
 #   A520 AORUS ELITE
-chip "it8688_60050607-*" "it8688_70050607-*" "it8689_61050607-*" "it8689_71050607-*"
+chip "it8688_60050607-*" "it8689_61050607-*" "it8688_70050607-*" "it8689_71050607-*"
     label in0     "CPU Vcore"
     label in1     "+3.3V"
     compute in1   @ * 1.649, @ / 1.649
@@ -668,6 +1085,42 @@ chip "it8688_60050607-*" "it8688_70050607-*" "it8689_61050607-*" "it8689_7105060
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x6008090B
+# Motherboards:
+#   B550 AORUS PRO
+#   B550 AORUS PRO AC
+#   B550 AORUS PRO AX
+#   B550 AORUS PRO V2
+#   B550 VISION D
+#   B550 VISION D-P
+# SIV 0x6108090B
+# Motherboards:
+#   B550 AORUS MASTER
+chip "it8792_6008090b-*" "it8792_6108090b-*"
+    label in0     "DDRVTT CH(A/B)"
+    label in1     "Chipset Core"
+    label in3     "CPU VDD18"
+    label in4     "PM_2V5"
+    compute in4   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in2
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x61020507
 # Motherboards:
@@ -680,7 +1133,7 @@ chip "it8688_60050607-*" "it8688_70050607-*" "it8689_61050607-*" "it8689_7105060
 #   A520M DS3H V2
 #   A520M K
 #   A520M K V2
-chip "it8688_70020507-*" "it8689_61020507-*" "it8689_71020507-*"
+chip "it8689_61020507-*" "it8688_70020507-*" "it8689_71020507-*"
     label in0     "CPU Vcore"
     label in1     "+3.3V"
     compute in1   @ * 1.649, @ / 1.649
@@ -700,6 +1153,16 @@ chip "it8688_70020507-*" "it8689_61020507-*" "it8689_71020507-*"
     label fan2    "SYS_FAN1"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x80030407
 # Motherboards:
@@ -730,6 +1193,25 @@ chip "it8688_80030407-*" "it8688_80060607-*" "it8688_8008090a-*" "it8688_800a090
     label in4     "CPU VCORE SOC"
     label in5     "CPU VDDP"
     label in6     "DRAM CH(A/B)"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp1
+    ignore temp2
+    ignore temp3
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore fan1
+    ignore fan2
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm1
+    ignore pwm2
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x80030407
 # Motherboards:
@@ -745,6 +1227,22 @@ chip "it8689_80030407-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore temp2
+    ignore temp4
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x80060607
 # Motherboards:
@@ -771,6 +1269,14 @@ chip "it8689_80060607-*"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
     label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
 
 # SIV 0x8008090A
 # Motherboards:
@@ -798,6 +1304,67 @@ chip "it8689_8008090a-*" "it8689_800a090a-*" "it8689_8108090a-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x8008090A
+# Motherboards:
+#   X570S AORUS PRO AX
+chip "it87952_8008090a-*"
+    label in2     "Chipset Core"
+    label in4     "CPU VDD18"
+    label in5     "PM_CLDO12"
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x800A090A
+# Motherboards:
+#   X570S AORUS MASTER
+chip "it87952_800a090a-*"
+    label in2     "Chipset Core"
+    label in4     "CPU VDD18"
+    label in5     "PM_CLDO12"
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x90030406
 # Motherboards:
@@ -823,6 +1390,16 @@ chip "it8689_90030406-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore temp4
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x90030506
 # Motherboards:
@@ -867,6 +1444,15 @@ chip "it8689_90030506-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore temp4
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x90030606
 # Motherboards:
@@ -893,21 +1479,71 @@ chip "it8689_90030606-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x90040507
 # Motherboards:
 #   B650EM C
 #   B650EM DS3H WIFI6E
 #   B650EM FORCE WIFI6E
-# SIV 0xA0030506
+# SIV 0xA0040507
 # Motherboards:
-#   B840M H
-chip "it8689_90040507-*" "it8696_a0030506-*"
+#   B840M DS3H
+#   B840M DS3H WIFI6
+#   B840M EAGLE WIFI6
+#   B840M FORCE WIFI6E
+#   B840M GAMING X WIFI6E
+#   B850M AORUS STEALTH
+#   B850M AORUS STEALTH ICE
+#   B850M C
+#   B850M D3HP
+#   B850M DS3H
+#   B850M DS3H ICE
+#   B850M EAGLE WIFI6E
+#   B850M EAGLE WIFI6E ICE
+#   B850M EAGLE WIFI7
+#   B850M FORCE
+#   B850M FORCE V2
+#   B850M FORCE WIFI6E
+#   B850M FORCE WIFI6E V2
+#   B850M GAMING X WIFI6E
+chip "it8696_90040507-*" "it8696_a0040507-*"
+    label in0     "CPU Vcore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU VCORE MISC"
+    label in6     "CPU VDDIO MEM"
     label temp1   "System 1"
     label temp2   "PCH"
     label temp3   "CPU"
     label temp4   "PCIEX16"
     label temp5   "VRM MOS"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "FAN2_PUMP"
+    label fan5    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "FAN2_PUMP"
+    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp6
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
 
 # SIV 0x90040606
 # Motherboards:
@@ -938,6 +1574,12 @@ chip "it8689_90040606-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan5
+    ignore fan6
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x90050506
 # Motherboards:
@@ -969,6 +1611,11 @@ chip "it8689_90050506-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore temp6
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x90050606
 # Motherboards:
@@ -1005,245 +1652,10 @@ chip "it8689_90050606-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
-
-# SIV 0x90060606
-# Motherboards:
-#   B650 AORUS ELITE
-#   B650 AORUS ELITE AX
-#   B650 AORUS ELITE AX ICE
-#   B650 AORUS ELITE AX V2
-#   B650 AORUS ELITE V2
-#   B650E AORUS ELITE X AX ICE
-#   B650E AORUS STEALTH ICE
-#   B650M AORUS ELITE
-#   B650M AORUS ELITE AX
-#   B650M AORUS ELITE AX ICE
-#   B650M AORUS PRO AX
-chip "it8689_90060606-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label temp6   "VSOCMOS"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label fan4    "SYS_FAN3"
-    label fan5    "CPU_OPT"
-    label fan6    "SYS_FAN4_PUMP"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-    label pwm4    "SYS_FAN3"
-    label pwm5    "CPU_OPT"
-    label pwm6    "SYS_FAN4_PUMP"
-
-# SIV 0x90080909
-# Motherboards:
-#   B650 AERO G
-#   B650 AORUS PRO AX
-#   B650E AORUS PRO X USB4
-#   X670E AORUS PRO X
-# SIV 0x90090909
-# Motherboards:
-#   B650E AORUS TACHYON
-# SIV 0x900A0909
-# Motherboards:
-#   B650E AORUS MASTER
-#   X670E AORUS MASTER
-#   X670E AORUS XTREME
-# SIV 0x910A0909
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it8689_90080909-*" "it8689_90090909-*" "it8689_900a0909-*" "it8696_910a0909-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label temp6   "EC_TEMP1"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label fan4    "SYS_FAN3"
-    label fan5    "CPU_OPT"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-    label pwm4    "SYS_FAN3"
-    label pwm5    "CPU_OPT"
-
-# SIV 0x91040606
-# Motherboards:
-#   B650I AORUS ULTRA
-chip "it8689_91040606-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label temp6   "VSOCMOS"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label fan5    "CPU_OPT"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-    label pwm5    "CPU_OPT"
-
-# SIV 0x92040606
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it8689_92040606-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label temp6   "VSOCMOS"
-
-# SIV 0x9A0A0908
-# Motherboards:
-#   TRX50 AERO D
-chip "it8689_9a0a0908-*"
-    label in0     "CPU Vcore0"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU Vcore1"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label temp6   "EC_TEMP1"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label fan4    "SYS_FAN3"
-    label fan5    "CPU_OPT"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-    label pwm4    "SYS_FAN3"
-    label pwm5    "CPU_OPT"
-
-# SIV 0x9A0B0908
-# Motherboards:
-#   TRX50 AI TOP
-chip "it8689_9a0b0908-*"
-    label in0     "CPU Vcore0"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU Vcore1"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label temp6   "EC_TEMP1"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label fan4    "PCH_FAN"
-    label fan5    "CPU_OPT"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-    label pwm4    "PCH_FAN"
-    label pwm5    "CPU_OPT"
-
-# SIV 0xA0030506
-# Motherboards:
-#   B840M H
-chip "it8689_a0030506-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-
-# SIV 0x90040507
-# Motherboards:
-#   B650EM C
-#   B650EM DS3H WIFI6E
-#   B650EM FORCE WIFI6E
-chip "it8696_90040507-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label in6     "CPU VDDIO MEM"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "FAN2_PUMP"
-    label fan5    "CPU_OPT"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "FAN2_PUMP"
-    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x90060507
 # Motherboards:
@@ -1300,6 +1712,183 @@ chip "it8696_90060507-*" "it8696_a0060507-*"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
     label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp6
+
+# SIV 0x90060606
+# Motherboards:
+#   B650 AORUS ELITE
+#   B650 AORUS ELITE AX
+#   B650 AORUS ELITE AX ICE
+#   B650 AORUS ELITE AX V2
+#   B650 AORUS ELITE V2
+#   B650E AORUS ELITE X AX ICE
+#   B650E AORUS STEALTH ICE
+#   B650M AORUS ELITE
+#   B650M AORUS ELITE AX
+#   B650M AORUS ELITE AX ICE
+#   B650M AORUS PRO AX
+chip "it8689_90060606-*"
+    label in0     "CPU Vcore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU VCORE MISC"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "VSOCMOS"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label fan4    "SYS_FAN3"
+    label fan5    "CPU_OPT"
+    label fan6    "SYS_FAN4_PUMP"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    label pwm4    "SYS_FAN3"
+    label pwm5    "CPU_OPT"
+    label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+
+# SIV 0x90080909
+# Motherboards:
+#   B650 AERO G
+#   B650 AORUS PRO AX
+#   B650E AORUS PRO X USB4
+#   X670E AORUS PRO X
+# SIV 0x90090909
+# Motherboards:
+#   B650E AORUS TACHYON
+# SIV 0x900A0909
+# Motherboards:
+#   B650E AORUS MASTER
+#   X670E AORUS MASTER
+#   X670E AORUS XTREME
+# SIV 0x910A0909
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it8689_90080909-*" "it8689_90090909-*" "it8689_900a0909-*" "it8696_910a0909-*"
+    label in0     "CPU Vcore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU VCORE MISC"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "EC_TEMP1"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label fan4    "SYS_FAN3"
+    label fan5    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    label pwm4    "SYS_FAN3"
+    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x90080909
+# Motherboards:
+#   B650 AERO G
+#   B650 AORUS PRO AX
+#   B650E AORUS PRO X USB4
+#   X670E AORUS PRO X
+chip "it8792_90080909-*"
+    label in2     "VDD11 SIO"
+    label in4     "CPU VDD 18"
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x90090909
+# Motherboards:
+#   B650E AORUS TACHYON
+chip "it8792_90090909-*"
+    label in2     "VDD11 SIO"
+    label in4     "CPU VDD 18"
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x900A0909
+# Motherboards:
+#   B650E AORUS MASTER
+#   X670E AORUS MASTER
+#   X670E AORUS XTREME
+# SIV 0x910A0909
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it8792_900a0909-*" "it8792_910a0909-*"
+    label in2     "VDD11 SIO"
+    label in4     "CPU VDD 18"
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x91030506
 # Motherboards:
@@ -1325,11 +1914,69 @@ chip "it8696_91030506-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1_PUMP"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm6
+
+# SIV 0x91040606
+# Motherboards:
+#   B650I AORUS ULTRA
+chip "it8689_91040606-*"
+    label in0     "CPU Vcore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU VCORE MISC"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "VSOCMOS"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label fan5    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
 
 # SIV 0x92040606
 # Motherboards:
 #   Motherboards: Names not currently known.
 chip "it8696_92040606-*"
+    label in0     "CPU Vcore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU VCORE MISC"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "VSOCMOS"
     label fan1    "CPU_FAN"
     label fan2    "SYS_FAN1"
     label fan3    "FAN2_PUMP"
@@ -1338,6 +1985,170 @@ chip "it8696_92040606-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "FAN2_PUMP"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
+
+# SIV 0x9A0A0908
+# Motherboards:
+#   TRX50 AERO D
+chip "it8689_9a0a0908-*"
+    label in0     "CPU Vcore0"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU Vcore1"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "EC_TEMP1"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label fan4    "SYS_FAN3"
+    label fan5    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    label pwm4    "SYS_FAN3"
+    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x9A0A0908
+# Motherboards:
+#   TRX50 AERO D
+chip "it87952_9a0a0908-*"
+    label in2     "CPU VDD11 S3"
+    label in4     "CPU VDD18 S5"
+    label temp1   "PCIEX16_2"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x9A0B0908
+# Motherboards:
+#   TRX50 AI TOP
+chip "it8689_9a0b0908-*"
+    label in0     "CPU Vcore0"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU Vcore1"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "EC_TEMP1"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label fan4    "PCH_FAN"
+    label fan5    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    label pwm4    "PCH_FAN"
+    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x9A0B0908
+# Motherboards:
+#   TRX50 AI TOP
+chip "it87952_9a0b0908-*"
+    label in2     "CPU VDD11 S3"
+    label in4     "CPU VDD18 S5"
+    label temp1   "PCIEX16_2"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "MOS_FAN1"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label fan6    "MOS_FAN2"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "MOS_FAN1"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    label pwm6    "MOS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0xA0030506
+# Motherboards:
+#   B840M H
+chip "it8696_a0030506-*"
+    label in0     "CPU Vcore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU VCORE MISC"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0xA0030507
 # Motherboards:
@@ -1364,6 +2175,14 @@ chip "it8696_a0030507-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0xA0030607
 # Motherboards:
@@ -1391,52 +2210,13 @@ chip "it8696_a0030607-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "CPU_OPT"
-
-# SIV 0xA0040507
-# Motherboards:
-#   B840M DS3H
-#   B840M DS3H WIFI6
-#   B840M EAGLE WIFI6
-#   B840M FORCE WIFI6E
-#   B840M GAMING X WIFI6E
-#   B850M AORUS STEALTH
-#   B850M AORUS STEALTH ICE
-#   B850M C
-#   B850M D3HP
-#   B850M DS3H
-#   B850M DS3H ICE
-#   B850M EAGLE WIFI6E
-#   B850M EAGLE WIFI6E ICE
-#   B850M EAGLE WIFI7
-#   B850M FORCE
-#   B850M FORCE V2
-#   B850M FORCE WIFI6E
-#   B850M FORCE WIFI6E V2
-#   B850M GAMING X WIFI6E
-chip "it8696_a0040507-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label in6     "CPU VDDIO MEM"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "FAN2_PUMP"
-    label fan5    "CPU_OPT"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "FAN2_PUMP"
-    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0xA0040607
 # Motherboards:
@@ -1466,6 +2246,11 @@ chip "it8696_a0040607-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan5
+    ignore fan6
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0xA0050507
 # Motherboards:
@@ -1496,6 +2281,10 @@ chip "it8696_a0050507-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp6
+    ignore fan6
+    ignore pwm6
 
 # SIV 0xA0050607
 # Motherboards:
@@ -1527,6 +2316,9 @@ chip "it8696_a0050607-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0xA0060607
 # Motherboards:
@@ -1560,6 +2352,7 @@ chip "it8696_a0060607-*"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
     label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
 
 # SIV 0xA0080908
 # Motherboards:
@@ -1628,6 +2421,44 @@ chip "it8696_a0080908-*" "it8696_a00a0908-*" "it8696_a00b090a-*" "it8696_a00c090
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0xA0080908
+# Motherboards:
+#   B850 AORUS ELITE X3D
+#   X870 AORUS ELITE X3D
+#   X870 AORUS ELITE X3D ICE
+#   X870E AORUS ELITE X3D
+#   X870E AORUS ELITE X3D ICE
+#   X870E AORUS PRO X3D
+#   X870E AORUS PRO X3D ICE
+#   X870E EAGLE WIFI7
+#   X870E EAGLE X3D WIFI7
+# SIV 0xA3080908
+# Motherboards:
+#   X870E AERO X3D DARK WOOD
+#   X870E AERO X3D WOOD
+chip "it87952_a0080908-*" "it87952_a3080908-*"
+    label in2     "PM VCC18"
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0xA008090A
 # Motherboards:
@@ -1676,515 +2507,9 @@ chip "it8696_a008090a-*" "it8696_a00a090a-*" "it8696_a108090a-*" "it8696_a10a090
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
-
-# SIV 0xA1030507
-# Motherboards:
-#   A620M GAMING X
-#   B840M D3HP
-#   B840M D3HP WIFI6E
-#   B840M GAMING PLUS WIFI6E
-chip "it8696_a1030507-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label in6     "CPU VDDIO MEM"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-
-# SIV 0xA1040507
-# Motherboards:
-#   B850I AORUS PRO
-#   X870I AORUS PRO ICE
-chip "it8696_a1040507-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label in6     "CPU VDDIO MEM"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "PT_FAN"
-    label fan5    "CPU_OPT"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "PT_FAN"
-    label pwm5    "CPU_OPT"
-
-# SIV 0xA1060507
-# Motherboards:
-#   B850 AORUS ELITE-P ICE
-chip "it8696_a1060507-*"
-    label in0     "CPU Vcore"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VCORE SOC"
-    label in5     "CPU VCORE MISC"
-    label in6     "CPU VDDIO MEM"
-    label temp1   "System 1"
-    label temp2   "VRM MOS"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "PCH"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label fan4    "SYS_FAN3"
-    label fan5    "CPU_OPT"
-    label fan6    "SYS_FAN4_PUMP"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-    label pwm4    "SYS_FAN3"
-    label pwm5    "CPU_OPT"
-    label pwm6    "SYS_FAN4_PUMP"
-
-# SIV 0x1008090B
-# Motherboards:
-#   GA-AX370-GAMING 5
-#   GA-AX370-GAMING K7
-chip "it8792_1008090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "Chipset Core"
-    label in4     "CPU VDD18"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x2008090D
-# Motherboards:
-#   X399 AORUS GAMING 7
-#   X399 AORUS PRO
-chip "it8792_2008090d-*"
-    label in0     "CPU VCORE SIO"
-    label in1     "DDRVPP CH(A/B)"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "Chipset Core"
-    label in3     "5VSB"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VDD18"
-    label in5     "DDRVPP CH(C/D)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x2108090D
-# Motherboards:
-#   X399 AORUS XTREME
-#   X399 DESIGNARE EX
-# SIV 0x2208090D
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it8792_2108090d-*" "it8792_2208090d-*"
-    label in0     "CPU VCORE SIO"
-    label in1     "DDRVPP CH(A/B)"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "Chipset Core"
-    label in3     "5VSB"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "CPU VDD18"
-    label in5     "DDRVPP CH(C/D)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX16_2"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x30080907
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it8792_30080907-*"
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP1"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x3008090B
-# Motherboards:
-#   X470 AORUS GAMING 7 WIFI
-#   X470 AORUS GAMING 7 WIFI-50
-chip "it8792_3008090b-*"
-    label in0     "DDRVTT CH(A/B)"
-    label in1     "Chipset Core"
-    label in3     "CPU VDD18"
-    label in4     "Chipset Core 2.5V"
-    compute in4   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x3108090B
-# Motherboards:
-#   X470 AORUS GAMING 5 WIFI
-#   X470 AORUS ULTRA GAMING
-chip "it8792_3108090b-*"
-    label in0     "DDRVTT CH(A/B)"
-    label in1     "Chipset Core"
-    label in3     "CPU VDD18"
-    label in4     "Chipset Core 2.5V"
-    compute in4   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP1"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x4008090A
-# Motherboards:
-#   X570 AORUS XTREME
-# SIV 0x8008090A
-# Motherboards:
-#   X570S AORUS PRO AX
-# SIV 0x8108090A
-# Motherboards:
-#   X570S AERO G
-chip "it8792_4008090a-*" "it87952_8008090a-*" "it87952_8108090a-*"
-    label in2     "Chipset Core"
-    label in4     "CPU VDD18"
-    label in5     "PM_CLDO12"
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x4008090B
-# Motherboards:
-#   X570 AORUS PRO
-#   X570 AORUS PRO WIFI
-#   X570 AORUS ULTRA
-# SIV 0x4108090B
-# Motherboards:
-#   X570 AORUS XTREME
-# SIV 0x4208090B
-# Motherboards:
-#   X570 AORUS MASTER
-# SIV 0x4308090B
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it8792_4008090b-*" "it8792_4108090b-*" "it8792_4208090b-*" "it8792_4308090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "Chipset Core"
-    label in4     "CPU VDD18"
-    label in5     "PM_CLDO12"
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x5008090B
-# Motherboards:
-#   TRX40 AORUS PRO WIFI
-#   TRX40 DESIGNARE
-# SIV 0x5108090B
-# Motherboards:
-#   TRX40 AORUS MASTER
-chip "it8792_5008090b-*" "it8792_5108090b-*"
-    label in1     "DDRVPP CH(A/B)"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "Chipset Core"
-    label in4     "CPU VDD18"
-    label in5     "DDRVPP CH(C/D)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX16_2"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5A_PUMP"
-    label fan2    "SYS_FAN6A_PUMP"
-    label fan3    "MOS_FAN"
-    label pwm1    "SYS_FAN5A_PUMP/SYS_FAN5B_PUMP"
-    label pwm2    "SYS_FAN6A_PUMP/SYS_FAN6B_PUMP"
-    label pwm3    "MOS_FAN"
-
-# SIV 0x5208090B
-# Motherboards:
-#   TRX40 AORUS XTREME
-chip "it8792_5208090b-*"
-    label in1     "DDRVPP CH(A/B)"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "Chipset Core"
-    label in4     "CPU VDD18"
-    label in5     "DDRVPP CH(C/D)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX16_2"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5A_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5A_PUMP/SYS_FAN5B_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x5308090A
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it8792_5308090a-*"
-    label in1     "DDRVPP CH(A/B)"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "Chipset Core"
-    label in5     "DDRVPP CH(C/D)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX16_2"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x6008090B
-# Motherboards:
-#   B550 AORUS PRO
-#   B550 AORUS PRO AC
-#   B550 AORUS PRO AX
-#   B550 AORUS PRO V2
-#   B550 VISION D
-#   B550 VISION D-P
-# SIV 0x6108090B
-# Motherboards:
-#   B550 AORUS MASTER
-chip "it8792_6008090b-*" "it8792_6108090b-*"
-    label in0     "DDRVTT CH(A/B)"
-    label in1     "Chipset Core"
-    label in3     "CPU VDD18"
-    label in4     "PM_2V5"
-    compute in4   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX4"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x90080909
-# Motherboards:
-#   B650 AERO G
-#   B650 AORUS PRO AX
-#   B650E AORUS PRO X USB4
-#   X670E AORUS PRO X
-chip "it8792_90080909-*"
-    label in2     "VDD11 SIO"
-    label in4     "CPU VDD 18"
-    label temp1   "PCIEX4"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x90090909
-# Motherboards:
-#   B650E AORUS TACHYON
-chip "it8792_90090909-*"
-    label in2     "VDD11 SIO"
-    label in4     "CPU VDD 18"
-    label temp1   "PCIEX4"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-
-# SIV 0x900A0909
-# Motherboards:
-#   B650E AORUS MASTER
-#   X670E AORUS MASTER
-#   X670E AORUS XTREME
-# SIV 0x910A0909
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it8792_900a0909-*" "it8792_910a0909-*"
-    label in2     "VDD11 SIO"
-    label in4     "CPU VDD 18"
-    label temp1   "PCIEX4"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
-
-# SIV 0x800A090A
-# Motherboards:
-#   X570S AORUS MASTER
-chip "it87952_800a090a-*"
-    label in2     "Chipset Core"
-    label in4     "CPU VDD18"
-    label in5     "PM_CLDO12"
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
-
-# SIV 0x9A0A0908
-# Motherboards:
-#   TRX50 AERO D
-chip "it87952_9a0a0908-*"
-    label in2     "CPU VDD11 S3"
-    label in4     "CPU VDD18 S5"
-    label temp1   "PCIEX16_2"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
-
-# SIV 0x9A0B0908
-# Motherboards:
-#   TRX50 AI TOP
-chip "it87952_9a0b0908-*"
-    label in2     "CPU VDD11 S3"
-    label in4     "CPU VDD18 S5"
-    label temp1   "PCIEX16_2"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "MOS_FAN1"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label fan6    "MOS_FAN2"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "MOS_FAN1"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
-    label pwm6    "MOS_FAN2"
-
-# SIV 0xA0080908
-# Motherboards:
-#   B850 AORUS ELITE X3D
-#   X870 AORUS ELITE X3D
-#   X870 AORUS ELITE X3D ICE
-#   X870E AORUS ELITE X3D
-#   X870E AORUS ELITE X3D ICE
-#   X870E AORUS PRO X3D
-#   X870E AORUS PRO X3D ICE
-#   X870E EAGLE WIFI7
-#   X870E EAGLE X3D WIFI7
-# SIV 0xA3080908
-# Motherboards:
-#   X870E AERO X3D DARK WOOD
-#   X870E AERO X3D WOOD
-chip "it87952_a0080908-*" "it87952_a3080908-*"
-    label in2     "PM VCC18"
-    label temp1   "PCIEX4"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0xA008090A
 # Motherboards:
@@ -2219,6 +2544,12 @@ chip "it87952_a008090a-*" "it87952_a108090a-*" "it87952_a208090a-*" "it87952_a30
     label pwm1    "SYS_FAN5_PUMP"
     label pwm2    "SYS_FAN6_PUMP"
     label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0xA00A0908
 # Motherboards:
@@ -2239,6 +2570,14 @@ chip "it87952_a00a0908-*"
     label pwm3    "SYS_FAN4"
     label pwm4    "SYS_FAN7_PUMP"
     label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0xA00A090A
 # Motherboards:
@@ -2266,6 +2605,12 @@ chip "it87952_a00a090a-*" "it87952_a10a090a-*" "it87952_a20a090a-*"
     label pwm3    "SYS_FAN4"
     label pwm4    "SYS_FAN7_PUMP"
     label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0xA00B090A
 # Motherboards:
@@ -2289,14 +2634,17 @@ chip "it87952_a00b090a-*"
     label pwm4    "SYS_FAN7_PUMP"
     label pwm5    "SYS_FAN8_PUMP"
     label pwm6    "DDR_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0xA00C0908
 # Motherboards:
 #   Motherboards: Names not currently known.
-# SIV 0xA10C0908
-# Motherboards:
-#   X870E AORUS XTREME X3D AI TOP
-chip "it87952_a00c0908-*" "it87952_a10c0908-*"
+chip "it87952_a00c0908-*"
     label in2     "PM VCC18"
     label temp1   "PCIEX4"
     label temp2   "EC_TEMP2"
@@ -2315,6 +2663,14 @@ chip "it87952_a00c0908-*" "it87952_a10c0908-*"
     label pwm5    "SYS_FAN8_PUMP"
     label pwm6    "DDR_FAN"
     label pwm7    "M2_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0xA00C090A
 # Motherboards:
@@ -2340,3 +2696,147 @@ chip "it87952_a00c090a-*"
     label pwm5    "SYS_FAN8_PUMP"
     label pwm6    "DDR_FAN"
     label pwm7    "M2_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0xA1030507
+# Motherboards:
+#   A620M GAMING X
+#   B840M D3HP
+#   B840M D3HP WIFI6E
+#   B840M GAMING PLUS WIFI6E
+chip "it8696_a1030507-*"
+    label in0     "CPU Vcore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU VCORE MISC"
+    label in6     "CPU VDDIO MEM"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
+
+# SIV 0xA1040507
+# Motherboards:
+#   B850I AORUS PRO
+#   X870I AORUS PRO ICE
+chip "it8696_a1040507-*"
+    label in0     "CPU Vcore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU VCORE MISC"
+    label in6     "CPU VDDIO MEM"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "PT_FAN"
+    label fan5    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "PT_FAN"
+    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp6
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
+
+# SIV 0xA1060507
+# Motherboards:
+#   B850 AORUS ELITE-P ICE
+chip "it8696_a1060507-*"
+    label in0     "CPU Vcore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VCORE SOC"
+    label in5     "CPU VCORE MISC"
+    label in6     "CPU VDDIO MEM"
+    label temp1   "System 1"
+    label temp2   "VRM MOS"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "PCH"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label fan4    "SYS_FAN3"
+    label fan5    "CPU_OPT"
+    label fan6    "SYS_FAN4_PUMP"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    label pwm4    "SYS_FAN3"
+    label pwm5    "CPU_OPT"
+    label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp6
+
+# SIV 0xA10C0908
+# Motherboards:
+#   X870E AORUS XTREME X3D AI TOP
+chip "it87952_a10c0908-*"
+    label in2     "PM VCC18"
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label fan6    "DDR_FAN"
+    label fan7    "M2_FAN"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    label pwm6    "DDR_FAN"
+    label pwm7    "M2_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8

--- a/Sensors configs/Gigabyte/configs/gigabyte-it87-intel-kabylakex.conf
+++ b/Sensors configs/Gigabyte/configs/gigabyte-it87-intel-kabylakex.conf
@@ -29,6 +29,12 @@ chip "it8686_2005080b-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
 
 # SIV 0x2008090B
 # Motherboards:
@@ -72,6 +78,10 @@ chip "it8686_2008090b-*" "it8686_2108090b-*" "it8686_2208090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x5008090A
 # Motherboards:
@@ -106,6 +116,10 @@ chip "it8688_5008090a-*" "it8688_5108090a-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x2005080B
 # Motherboards:
@@ -119,6 +133,19 @@ chip "it8792_2005080b-*"
     label temp3   "System 2"
     label fan1    "HPWR_FAN_PUMP"
     label pwm1    "HPWR_FAN_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in3
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore temp2
+    ignore fan2
+    ignore fan3
+    ignore pwm2
+    ignore pwm3
 
 # SIV 0x2008090B
 # Motherboards:
@@ -141,6 +168,14 @@ chip "it8792_2008090b-*"
     label pwm1    "HPWR_FAN_PUMP"
     label pwm2    "SYS_FAN5_PUMP"
     label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in3
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x2108090B
 # Motherboards:
@@ -161,6 +196,14 @@ chip "it8792_2108090b-*" "it8792_2208090b-*"
     label pwm1    "SYS_FAN6_PUMP"
     label pwm2    "SYS_FAN5_PUMP"
     label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in3
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x5008090A
 # Motherboards:
@@ -180,3 +223,11 @@ chip "it8792_5008090a-*" "it8792_5108090a-*"
     label pwm1    "SYS_FAN6_PUMP"
     label pwm2    "SYS_FAN5_PUMP"
     label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8

--- a/Sensors configs/Gigabyte/configs/gigabyte-it87-intel-skylakex.conf
+++ b/Sensors configs/Gigabyte/configs/gigabyte-it87-intel-skylakex.conf
@@ -30,6 +30,11 @@ chip "it8686_2005080b-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
 
 # SIV 0x2008090B
 # Motherboards:
@@ -74,6 +79,9 @@ chip "it8686_2008090b-*" "it8686_2108090b-*" "it8686_2208090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x5008090A
 # Motherboards:
@@ -109,6 +117,9 @@ chip "it8688_5008090a-*" "it8688_5108090a-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x2005080B
 # Motherboards:
@@ -124,6 +135,17 @@ chip "it8792_2005080b-*"
     label temp3   "System 2"
     label fan1    "HPWR_FAN_PUMP"
     label pwm1    "HPWR_FAN_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore temp2
+    ignore fan2
+    ignore fan3
+    ignore pwm2
+    ignore pwm3
 
 # SIV 0x2008090B
 # Motherboards:
@@ -148,6 +170,12 @@ chip "it8792_2008090b-*"
     label pwm1    "HPWR_FAN_PUMP"
     label pwm2    "SYS_FAN5_PUMP"
     label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x2108090B
 # Motherboards:
@@ -170,6 +198,12 @@ chip "it8792_2108090b-*" "it8792_2208090b-*"
     label pwm1    "SYS_FAN6_PUMP"
     label pwm2    "SYS_FAN5_PUMP"
     label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x5008090A
 # Motherboards:
@@ -191,3 +225,9 @@ chip "it8792_5008090a-*" "it8792_5108090a-*"
     label pwm1    "SYS_FAN6_PUMP"
     label pwm2    "SYS_FAN5_PUMP"
     label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in2
+    ignore in6
+    ignore in7
+    ignore in8

--- a/Sensors configs/Gigabyte/configs/gigabyte-it87-intel.conf
+++ b/Sensors configs/Gigabyte/configs/gigabyte-it87-intel.conf
@@ -29,6 +29,17 @@ chip "it8686_10020407-*"
     label fan2    "SYS_FAN1"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x10030407
 # Motherboards:
@@ -55,6 +66,15 @@ chip "it8686_10030407-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x10040607
 # Motherboards:
@@ -116,6 +136,11 @@ chip "it8686_10040607-*" "it8686_30040607-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan5
+    ignore fan6
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x10050607
 # Motherboards:
@@ -129,9 +154,9 @@ chip "it8686_10040607-*" "it8686_30040607-*"
 #   GA-Z270XP-SLI
 # SIV 0x1005060B
 # Motherboards:
+#   GA-Z270X-GAMING SOC
 #   GA-Z270X-Gaming 5
 #   GA-Z270X-Gaming K7
-#   GA-Z270X-GAMING SOC
 # SIV 0x30050607
 # Motherboards:
 #   B360 AORUS GAMING 3
@@ -170,6 +195,36 @@ chip "it8686_10050607-*" "it8686_1005060b-*" "it8686_30050607-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3_PUMP"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x1005060B
+# Motherboards:
+#   GA-Z270X-GAMING SOC
+#   GA-Z270X-Gaming 5
+#   GA-Z270X-Gaming K7
+chip "it8792_1005060b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore temp1
+    ignore temp2
+    ignore temp3
+    ignore fan1
+    ignore fan2
+    ignore fan3
+    ignore pwm1
+    ignore pwm2
+    ignore pwm3
 
 # SIV 0x1006090B
 # Motherboards:
@@ -197,6 +252,38 @@ chip "it8686_1006090b-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
+
+# SIV 0x1006090B
+# Motherboards:
+#   GA-Z270X-UD5
+chip "it8792_1006090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN4_PUMP"
+    label fan2    "SYS_FAN2"
+    label fan3    "SYS_FAN3"
+    label pwm1    "SYS_FAN4_PUMP"
+    label pwm2    "SYS_FAN2"
+    label pwm3    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x1008090B
 # Motherboards:
@@ -236,6 +323,38 @@ chip "it8686_1008090b-*" "it8686_3008090b-*" "it8686_3108090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x1008090B
+# Motherboards:
+#   GA-Z270X-Gaming 7
+#   GA-Z270X-Gaming 8
+# SIV 0x7008090B
+# Motherboards:
+#   Z590 AORUS PRO AX
+chip "it8792_1008090b-*" "it87952_7008090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x1108090B
 # Motherboards:
@@ -267,6 +386,34 @@ chip "it8686_1108090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x1108090B
+# Motherboards:
+#   GA-Z270X-Gaming 9
+chip "it8792_1108090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX16_2"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x20050809
 # Motherboards:
@@ -295,6 +442,37 @@ chip "it8686_20050809-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in4
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
+
+# SIV 0x20050809
+# Motherboards:
+#   X299 AORUS Gaming
+chip "it8792_20050809-*"
+    label in1     "DDRVPP CH(A/B)"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label temp1   "PCIEX16_2"
+    label temp3   "System 2"
+    label fan1    "HPWR_FAN_PUMP"
+    label pwm1    "HPWR_FAN_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore temp2
+    ignore fan2
+    ignore fan3
+    ignore pwm2
+    ignore pwm3
 
 # SIV 0x2308090B
 # Motherboards:
@@ -329,6 +507,38 @@ chip "it8686_2308090b-*" "it8686_2408090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x2308090B
+# Motherboards:
+#   Motherboards: Names not currently known.
+# SIV 0x2408090B
+# Motherboards:
+#   C621 AORUS XTREME
+chip "it8792_2308090b-*" "it8792_2408090b-*"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B/C)"
+    compute in5   @ * 1.649, @ / 1.649
+    label in8     "DDRVPP CH(D/E/F)"
+    compute in8   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX16_2"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN6_PUMP"
+    label fan2    "SYS_FAN5_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN6_PUMP"
+    label pwm2    "SYS_FAN5_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in3
+    ignore in6
+    ignore in7
 
 # SIV 0x30020407
 # Motherboards:
@@ -386,6 +596,17 @@ chip "it8686_30020407-*" "it8686_31020407-*"
     label fan2    "SYS_FAN1"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x30030407
 # Motherboards:
@@ -413,6 +634,44 @@ chip "it8686_30030407-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
+
+# SIV 0x3008090B
+# Motherboards:
+#   Z370 AORUS GAMING 5
+# SIV 0x3108090B
+# Motherboards:
+#   Z370 AORUS GAMING 7
+#   Z370 AORUS GAMING 7-OP
+chip "it8792_3008090b-*" "it8792_3108090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "HPWR_FAN_PUMP"
+    label fan2    "SYS_FAN5_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "HPWR_FAN_PUMP"
+    label pwm2    "SYS_FAN5_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x31050607
 # Motherboards:
@@ -448,6 +707,9 @@ chip "it8686_31050607-*"
     label pwm3    "SYS_FAN2A/SYS_FAN2B"
     label pwm4    "SYS_FAN3_PUMP"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x32050607
 # Motherboards:
@@ -479,6 +741,9 @@ chip "it8686_32050607-*"
     label pwm3    "SYS_FAN2A/SYS_FAN2B"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x40020407
 # Motherboards:
@@ -537,6 +802,25 @@ chip "it8686_40020407-*" "it8686_40030307-*" "it8686_40030407-*" "it8686_4004060
     label in4     "CPU VAXG"
     label in5     "CPU VCCSA"
     label in6     "DRAM CH(A/B)"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp1
+    ignore temp2
+    ignore temp3
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore fan1
+    ignore fan2
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm1
+    ignore pwm2
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x40020407
 # Motherboards:
@@ -550,6 +834,24 @@ chip "it8688_40020407-*"
     label fan2    "SYS_FAN1"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x40030307
 # Motherboards:
@@ -564,19 +866,28 @@ chip "it8688_40030307-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x40030407
 # Motherboards:
 #   Z390 I AORUS PRO WIFI
-# SIV 0xA0030407
-# Motherboards:
-#   H810M D2HX SI GEN5
-#   H810M GAMING WIFI6
-#   H810M H
-#   H810M H GEN5
-#   H810M S2H
-#   H810M S2H GEN5
-chip "it8688_40030407-*" "it8696_a0030407-*"
+chip "it8688_40030407-*"
     label temp1   "System 1"
     label temp2   "PCH"
     label temp3   "CPU"
@@ -587,6 +898,22 @@ chip "it8688_40030407-*" "it8696_a0030407-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore temp4
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x40040607
 # Motherboards:
@@ -614,6 +941,18 @@ chip "it8688_40040607-*" "it8688_42040607-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore fan5
+    ignore fan6
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x40050607
 # Motherboards:
@@ -637,6 +976,16 @@ chip "it8688_40050607-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3_PUMP"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x4006090B
 # Motherboards:
@@ -657,6 +1006,54 @@ chip "it8688_4006090b-*" "it8688_4106090b-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
+
+# SIV 0x4006090B
+# Motherboards:
+#   Motherboards: Names not currently known.
+# SIV 0x4106090B
+# Motherboards:
+#   Motherboards: Names not currently known.
+# SIV 0x6306090B
+# Motherboards:
+#   Motherboards: Names not currently known.
+# SIV 0x6406090B
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it8792_4006090b-*" "it8792_4106090b-*" "it8792_6306090b-*" "it8792_6406090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN3_PUMP"
+    label fan2    "SYS_FAN4_PUMP"
+    label fan3    "SYS_FAN2"
+    label pwm1    "SYS_FAN3_PUMP"
+    label pwm2    "SYS_FAN4_PUMP"
+    label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x4008090A
 # Motherboards:
@@ -670,32 +1067,7 @@ chip "it8688_4006090b-*" "it8688_4106090b-*"
 #   Z390 AORUS PRO WIFI
 #   Z390 AORUS ULTRA
 #   Z390 AORUS XTREME
-# SIV 0xA008090B
-# Motherboards:
-#   Z890 AORUS ELITE X ICE
-#   Z890 AORUS PRO ICE
-# SIV 0xA009090B
-# Motherboards:
-#   Z890 AORUS TACHYON DUO X ICE
-#   Z890 AORUS TACHYON ICE
-# SIV 0xA00A080B
-# Motherboards:
-#   W790 AI TOP
-# SIV 0xA00A090B
-# Motherboards:
-#   Z890 AORUS MASTER
-# SIV 0xA00B090B
-# Motherboards:
-#   Z890 AORUS XTREME AI TOP
-# SIV 0xA108090B
-# Motherboards:
-#   W880 AI TOP
-#   Z890 AERO D
-#   Z890 AI TOP
-# SIV 0xA10A090B
-# Motherboards:
-#   Z890 AORUS MASTER AI TOP
-chip "it8688_4008090a-*" "it8688_4008090b-*" "it8696_a008090b-*" "it8696_a009090b-*" "it8696_a00a080b-*" "it8696_a00a090b-*" "it8696_a00b090b-*" "it8696_a108090b-*" "it8696_a10a090b-*"
+chip "it8688_4008090a-*" "it8688_4008090b-*"
     label temp1   "System 1"
     label temp2   "PCH"
     label temp3   "CPU"
@@ -712,6 +1084,79 @@ chip "it8688_4008090a-*" "it8688_4008090b-*" "it8696_a008090b-*" "it8696_a009090
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x4008090A
+# Motherboards:
+#   Z390 AORUS XTREME WATERFORCE
+#   Z390 AORUS XTREME WATERFORCE 5G
+chip "it8792_4008090a-*"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN6_PUMP"
+    label fan2    "SYS_FAN5_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN6_PUMP"
+    label pwm2    "SYS_FAN5_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x4008090B
+# Motherboards:
+#   Z390 AORUS MASTER
+#   Z390 AORUS MASTER G2 EDITION
+#   Z390 AORUS PRO
+#   Z390 AORUS PRO WIFI
+#   Z390 AORUS ULTRA
+#   Z390 AORUS XTREME
+# SIV 0x6008090B
+# Motherboards:
+#   Z490 AORUS PRO AX
+#   Z490 VISION D
+# SIV 0x6308090B
+# Motherboards:
+#   W480 VISION D
+chip "it8792_4008090b-*" "it8792_6008090b-*" "it8792_6308090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN6_PUMP"
+    label fan2    "SYS_FAN5_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN6_PUMP"
+    label pwm2    "SYS_FAN5_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in3
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x41030607
 # Motherboards:
@@ -729,6 +1174,20 @@ chip "it8688_41030607-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x60020407
 # Motherboards:
@@ -779,6 +1238,17 @@ chip "it8688_60020407-*" "it8689_61020407-*" "it8689_70020407-*"
     label fan2    "SYS_FAN1"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x60030407
 # Motherboards:
@@ -811,6 +1281,15 @@ chip "it8688_60030407-*" "it8689_70030407-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x60040407
 # Motherboards:
@@ -842,6 +1321,13 @@ chip "it8688_60040407-*" "it8689_70040407-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan5
+    ignore fan6
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x60040607
 # Motherboards:
@@ -889,6 +1375,11 @@ chip "it8688_60040607-*" "it8689_70040607-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan5
+    ignore fan6
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x60050607
 # Motherboards:
@@ -931,6 +1422,9 @@ chip "it8688_60050607-*" "it8689_70050607-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x6008090B
 # Motherboards:
@@ -1005,6 +1499,9 @@ chip "it8688_6008090b-*" "it8688_6108090a-*" "it8688_6208090b-*" "it8688_6308090
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x61050607
 # Motherboards:
@@ -1044,6 +1541,63 @@ chip "it8688_61050607-*" "it8689_72050607-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x6108090A
+# Motherboards:
+#   Z490 AORUS XTREME WATERFORCE
+chip "it8792_6108090a-*"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN6_PUMP"
+    label fan2    "SYS_FAN5_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN6_PUMP"
+    label pwm2    "SYS_FAN5_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x6208090B
+# Motherboards:
+#   Z490 AORUS MASTER
+#   Z490 AORUS ULTRA
+#   Z490 AORUS ULTRA G2
+#   Z490 AORUS XTREME
+# SIV 0x6508090B
+# Motherboards:
+#   Z490 AORUS MASTER WATERFORCE
+chip "it8792_6208090b-*" "it8792_6508090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN6_PUMP"
+    label fan2    "SYS_FAN5_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN6_PUMP"
+    label pwm2    "SYS_FAN5_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x63030607
 # Motherboards:
@@ -1071,6 +1625,13 @@ chip "it8688_63030607-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2A/SYS_FAN2B"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x6306090B
 # Motherboards:
@@ -1101,6 +1662,13 @@ chip "it8688_6306090b-*" "it8688_6406090b-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x70030607
 # Motherboards:
@@ -1128,6 +1696,13 @@ chip "it8689_70030607-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x70060607
 # Motherboards:
@@ -1162,6 +1737,123 @@ chip "it8689_70060607-*"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
     label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+
+# SIV 0x7106090B
+# Motherboards:
+#   Z590 VISION G
+chip "it87952_7106090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan3    "SYS_FAN4"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore fan1
+    ignore fan2
+    ignore pwm1
+    ignore pwm2
+
+# SIV 0x7108090B
+# Motherboards:
+#   Z590 VISION D
+# SIV 0x7208090B
+# Motherboards:
+#   Z590 AORUS TACHYON
+# SIV 0x7308090B
+# Motherboards:
+#   Z590 AORUS ULTRA
+chip "it87952_7108090b-*" "it87952_7208090b-*" "it87952_7308090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x710A090A
+# Motherboards:
+#   Z590 AORUS XTREME WATERFORCE
+chip "it87952_710a090a-*"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x710A090B
+# Motherboards:
+#   Z590 AORUS XTREME
+# SIV 0x720A090B
+# Motherboards:
+#   Z590 AORUS MASTER
+# SIV 0x730A090B
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it87952_710a090b-*" "it87952_720a090b-*" "it87952_730a090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH Core"
+    label in4     "CPU VCCIO"
+    label in5     "DDRVPP CH(A/B)"
+    compute in5   @ * 1.649, @ / 1.649
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x80020406
 # Motherboards:
@@ -1186,6 +1878,18 @@ chip "it8689_80020406-*"
     label fan2    "SYS_FAN1"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x80020407
 # Motherboards:
@@ -1209,6 +1913,17 @@ chip "it8689_80020407-*"
     label fan2    "SYS_FAN1"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x80030406
 # Motherboards:
@@ -1246,6 +1961,16 @@ chip "it8689_80030406-*" "it8689_90030406-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore temp4
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x80030407
 # Motherboards:
@@ -1298,6 +2023,15 @@ chip "it8689_80030407-*" "it8689_90030407-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x80040606
 # Motherboards:
@@ -1357,6 +2091,12 @@ chip "it8689_80040606-*" "it8689_90040606-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan5
+    ignore fan6
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x80040607
 # Motherboards:
@@ -1416,6 +2156,11 @@ chip "it8689_80040607-*" "it8689_90040607-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan5
+    ignore fan6
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0x80050606
 # Motherboards:
@@ -1450,6 +2195,10 @@ chip "it8689_80050606-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x80050607
 # Motherboards:
@@ -1487,6 +2236,9 @@ chip "it8689_80050607-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x80060606
 # Motherboards:
@@ -1545,6 +2297,8 @@ chip "it8689_80060606-*" "it8689_90060606-*"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
     label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
 
 # SIV 0x80060607
 # Motherboards:
@@ -1602,6 +2356,7 @@ chip "it8689_80060607-*" "it8689_90060607-*"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
     label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
 
 # SIV 0x8008090A
 # Motherboards:
@@ -1669,6 +2424,38 @@ chip "it8689_8008090a-*" "it8689_800a0909-*" "it8689_800a090a-*" "it8689_8108090
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x8008090A
+# Motherboards:
+#   Z690 AERO D
+#   Z690 AORUS TACHYON
+# SIV 0x9108090A
+# Motherboards:
+#   Z790 AORUS TACHYON
+#   Z790 AORUS TACHYON X
+chip "it87952_8008090a-*" "it87952_9108090a-*"
+    label in1     "CPU VDD2"
+    label in2     "PCH 0.82V"
+    label in4     "CPU VCCSA"
+    label in5     "PCH 1.8V"
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x8008090B
 # Motherboards:
@@ -1705,6 +2492,91 @@ chip "it8689_8008090b-*" "it8689_9008090b-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x8008090B
+# Motherboards:
+#   B660 AORUS MASTER DDR4
+#   Z690 AERO G DDR4
+#   Z690 AORUS PRO DDR4
+# SIV 0x9008090B
+# Motherboards:
+#   B760 AORUS MASTER DDR4
+chip "it87952_8008090b-*" "it87952_9008090b-*"
+    label in1     "DDRVTT CH(A/B)"
+    label in2     "PCH 0.82V"
+    label in4     "CPU VCCSA"
+    label in5     "PCH 1.8V"
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x800A0909
+# Motherboards:
+#   Z690 AORUS XTREME WATERFORCE
+chip "it87952_800a0909-*"
+    label in2     "PCH 0.82V"
+    label in4     "CPU VCCSA"
+    label in5     "PCH 1.8V"
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x800A090A
+# Motherboards:
+#   Z690 AORUS XTREME
+chip "it87952_800a090a-*"
+    label in1     "CPU VDD2"
+    label in2     "PCH 0.82V"
+    label in4     "CPU VCCSA"
+    label in5     "PCH 1.8V"
+    label temp1   "PCIEX8"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x81030407
 # Motherboards:
@@ -1733,6 +2605,15 @@ chip "it8689_81030407-*" "it8689_91030407-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm6
 
 # SIV 0x81040606
 # Motherboards:
@@ -1766,6 +2647,12 @@ chip "it8689_81040606-*" "it8689_91040606-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
 
 # SIV 0x81040607
 # Motherboards:
@@ -1797,6 +2684,11 @@ chip "it8689_81040607-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
 
 # SIV 0x81050607
 # Motherboards:
@@ -1830,6 +2722,74 @@ chip "it8689_81050607-*"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
     label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+
+# SIV 0x8108090A
+# Motherboards:
+#   B660 AORUS MASTER
+#   Z690 AERO G
+#   Z690 AORUS PRO
+#   Z690 AORUS ULTRA
+# SIV 0x9008090A
+# Motherboards:
+#   Z790 AERO G
+#   Z790 AORUS PRO X
+#   Z790 AORUS PRO X WIFI7
+chip "it87952_8108090a-*" "it87952_9008090a-*"
+    label in1     "CPU VDD2"
+    label in2     "PCH 0.82V"
+    label in4     "CPU VCCSA"
+    label in5     "PCH 1.8V"
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0x810A090A
+# Motherboards:
+#   Z690 AORUS MASTER
+# SIV 0x900A090A
+# Motherboards:
+#   Z790 AORUS MASTER
+#   Z790 AORUS MASTER X
+# SIV 0x910A090A
+# Motherboards:
+#   Z790 AORUS XTREME
+#   Z790 AORUS XTREME X
+#   Z790 AORUS XTREME X ICE
+chip "it87952_810a090a-*" "it87952_900a090a-*" "it87952_910a090a-*"
+    label in1     "CPU VDD2"
+    label in2     "PCH 0.82V"
+    label in4     "CPU VCCSA"
+    label in5     "PCH 1.8V"
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x90050606
 # Motherboards:
@@ -1872,6 +2832,10 @@ chip "it8689_90050606-*"
     label pwm3    "SYS_FAN2A/SYS_FAN2B"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x90050607
 # Motherboards:
@@ -1906,6 +2870,36 @@ chip "it8689_90050607-*"
     label pwm3    "SYS_FAN2A/SYS_FAN2B"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
+
+# SIV 0x900A0909
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it87952_900a0909-*"
+    label in2     "PCH 0.82V"
+    label in4     "CPU VCCSA"
+    label in5     "PCH 1.8V"
+    label temp1   "PCIEX4"
+    label temp2   "EC_TEMP2"
+    label temp3   "System 2"
+    label fan1    "SYS_FAN5_PUMP"
+    label fan2    "SYS_FAN6_PUMP"
+    label fan3    "SYS_FAN4"
+    label fan4    "SYS_FAN7_PUMP"
+    label fan5    "SYS_FAN8_PUMP"
+    label pwm1    "SYS_FAN5_PUMP"
+    label pwm2    "SYS_FAN6_PUMP"
+    label pwm3    "SYS_FAN4"
+    label pwm4    "SYS_FAN7_PUMP"
+    label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0x91030406
 # Motherboards:
@@ -1921,6 +2915,22 @@ chip "it8689_91030406-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in1
+    ignore in2
+    ignore in3
+    ignore in4
+    ignore in5
+    ignore in6
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm6
 
 # SIV 0x91050606
 # Motherboards:
@@ -1952,6 +2962,10 @@ chip "it8689_91050606-*"
     label pwm3    "SYS_FAN2A/SYS_FAN2B"
     label pwm4    "FAN3_PUMP"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
+    ignore fan6
+    ignore pwm6
 
 # SIV 0x91060606
 # Motherboards:
@@ -1985,6 +2999,8 @@ chip "it8689_91060606-*"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
     label pwm6    "FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in6
 
 # SIV 0x91060607
 # Motherboards:
@@ -2018,111 +3034,13 @@ chip "it8689_91060607-*"
     label pwm4    "SYS_FAN3"
     label pwm5    "CPU_OPT"
     label pwm6    "FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
 
 # SIV 0xA0020407
 # Motherboards:
 #   H810M K
 #   H810M K GEN5
-# SIV 0xA0030407
-# Motherboards:
-#   H810M D2HX SI GEN5
-#   H810M GAMING WIFI6
-#   H810M H
-#   H810M H GEN5
-#   H810M S2H
-#   H810M S2H GEN5
-# SIV 0xA0030607
-# Motherboards:
-#   B860M D
-#   B860M E
-#   B860M E GEN5
-#   B860M H
-#   B860M K
-#   B860M K GEN5
-# SIV 0xA0040607
-# Motherboards:
-#   B860M C
-#   B860M D3HP
-#   B860M DS3H
-#   B860M DS3H WIFI6E
-#   B860M EAGLE
-#   B860M EAGLE PLUS WIFI6E
-#   B860M EAGLE V2
-#   B860M EAGLE WIFI6
-#   B860M EAGLE WIFI6 V2
-#   B860M GAMING WIFI6
-#   B860M GAMING X
-#   B860M GAMING X WIFI6E
-#   Z890M GAMING X
-# SIV 0xA0050607
-# Motherboards:
-#   B860 DS3H
-#   B860 DS3H WIFI6E
-#   B860 EAGLE WIFI6E
-#   Z890 UD
-#   Z890 UD WIFI6E
-# SIV 0xA0060607
-# Motherboards:
-#   B860 AORUS ELITE WIFI7 ICE
-#   B860 GAMING X WIFI6E
-#   B860M AORUS ELITE
-#   B860M AORUS ELITE WIFI6E
-#   B860M AORUS ELITE WIFI6E ICE
-#   B860M AORUS PRO WIFI7
-#   Z890 AERO G
-#   Z890 AORUS ELITE WIFI7
-#   Z890 AORUS ELITE WIFI7 ICE
-#   Z890 D PLUS
-#   Z890 EAGLE
-#   Z890 EAGLE WIFI7
-#   Z890 GAMING X WIFI7
-#   Z890M AORUS ELITE WIFI7
-#   Z890M AORUS ELITE WIFI7 ICE
-#   Z890M FORCE DUO X WIFI7
-# SIV 0xA008090B
-# Motherboards:
-#   Z890 AORUS ELITE X ICE
-#   Z890 AORUS PRO ICE
-# SIV 0xA009090B
-# Motherboards:
-#   Z890 AORUS TACHYON DUO X ICE
-#   Z890 AORUS TACHYON ICE
-# SIV 0xA00A090B
-# Motherboards:
-#   Z890 AORUS MASTER
-# SIV 0xA00B090B
-# Motherboards:
-#   Z890 AORUS XTREME AI TOP
-# SIV 0xA1020407
-# Motherboards:
-#   Motherboards: Names not currently known.
-# SIV 0xA1030607
-# Motherboards:
-#   B860I AORUS PRO ICE
-#   Z890I AORUS ULTRA
-# SIV 0xA1040607
-# Motherboards:
-#   Q870M D3H
-#   Z890M?
-# SIV 0xA1060607
-# Motherboards:
-#   Z890 AORUS ELITE DUO X
-#   Z890 AORUS ELITE WIFI7 PLUS
-#   Z890 EAGLE PLUS
-#   Z890 EAGLE WIFI7 PLUS
-# SIV 0xA108090B
-# Motherboards:
-#   W880 AI TOP
-#   Z890 AERO D
-#   Z890 AI TOP
-# SIV 0xA10A090B
-# Motherboards:
-#   Z890 AORUS MASTER AI TOP
-# SIV 0xA2030607
-# Motherboards:
-#   B860M D2H
-#   B860M POWER
-chip "it8689_a0020407-*" "it8689_a0030407-*" "it8689_a0030607-*" "it8689_a0040607-*" "it8689_a0050607-*" "it8689_a0060607-*" "it8689_a008090b-*" "it8689_a009090b-*" "it8689_a00a090b-*" "it8689_a00b090b-*" "it8689_a1020407-*" "it8689_a1030607-*" "it8689_a1040607-*" "it8689_a1060607-*" "it8689_a108090b-*" "it8689_a10a090b-*" "it8689_a2030607-*"
+chip "it8696_a0020407-*"
     label in0     "CPU VCore"
     label in1     "+3.3V"
     compute in1   @ * 1.649, @ / 1.649
@@ -2133,27 +3051,6 @@ chip "it8689_a0020407-*" "it8689_a0030407-*" "it8689_a0030607-*" "it8689_a004060
     label in4     "CPU VAXG"
     label in5     "CPU VNNAON"
     label in6     "CPU VCCSA"
-
-# SIV 0xA00A080B
-# Motherboards:
-#   W790 AI TOP
-chip "it8689_a00a080b-*"
-    label in0     "VCCIN"
-    label in1     "+3.3V"
-    compute in1   @ * 1.649, @ / 1.649
-    label in2     "+12V"
-    compute in2   @ * 6, @ / 6
-    label in3     "+5V"
-    compute in3   @ * 2.5, @ / 2.5
-    label in4     "VCCVNN"
-    label in5     "PCH 0.82V"
-    label in6     "PCH 1.8V"
-
-# SIV 0xA0020407
-# Motherboards:
-#   H810M K
-#   H810M K GEN5
-chip "it8696_a0020407-*"
     label temp1   "System 1"
     label temp2   "PCH"
     label temp3   "CPU"
@@ -2162,6 +3059,56 @@ chip "it8696_a0020407-*"
     label fan2    "SYS_FAN"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
+
+# SIV 0xA0030407
+# Motherboards:
+#   H810M D2HX SI GEN5
+#   H810M GAMING WIFI6
+#   H810M H
+#   H810M H GEN5
+#   H810M S2H
+#   H810M S2H GEN5
+chip "it8696_a0030407-*"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp5   "VRM MOS"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0xA0030607
 # Motherboards:
@@ -2172,6 +3119,16 @@ chip "it8696_a0020407-*"
 #   B860M K
 #   B860M K GEN5
 chip "it8696_a0030607-*"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
     label temp1   "System 1"
     label temp2   "PCH"
     label temp3   "CPU"
@@ -2184,6 +3141,13 @@ chip "it8696_a0030607-*"
     label pwm1    "CPU_FAN"
     label pwm2    "SYS_FAN1_PUMP"
     label pwm3    "SYS_FAN2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
 
 # SIV 0xA0040607
 # Motherboards:
@@ -2201,6 +3165,16 @@ chip "it8696_a0030607-*"
 #   B860M GAMING X WIFI6E
 #   Z890M GAMING X
 chip "it8696_a0040607-*"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
     label temp1   "System 1"
     label temp2   "PCH"
     label temp3   "CPU"
@@ -2215,6 +3189,11 @@ chip "it8696_a0040607-*"
     label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2_PUMP"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan6
+    ignore pwm4
+    ignore pwm6
 
 # SIV 0xA0050607
 # Motherboards:
@@ -2224,6 +3203,16 @@ chip "it8696_a0040607-*"
 #   Z890 UD
 #   Z890 UD WIFI6E
 chip "it8696_a0050607-*"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
     label temp1   "System 1"
     label temp2   "PCH"
     label temp3   "CPU"
@@ -2240,6 +3229,9 @@ chip "it8696_a0050607-*"
     label pwm3    "SYS_FAN2"
     label pwm4    "SYS_FAN3A/SYS_FAN3B"
     label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0xA0060607
 # Motherboards:
@@ -2260,569 +3252,88 @@ chip "it8696_a0050607-*"
 #   Z890M AORUS ELITE WIFI7 ICE
 #   Z890M FORCE DUO X WIFI7
 chip "it8696_a0060607-*"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label temp6   "System 2"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label fan4    "SYS_FAN3"
-    label fan5    "CPU_OPT"
-    label fan6    "SYS_FAN4_PUMP"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-    label pwm4    "SYS_FAN3"
-    label pwm5    "CPU_OPT"
-    label pwm6    "SYS_FAN4_PUMP"
-
-# SIV 0xA1020407
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it8696_a1020407-*"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp5   "VRM MOS"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1_PUMP"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1_PUMP"
-
-# SIV 0xA1030607
-# Motherboards:
-#   B860I AORUS PRO ICE
-#   Z890I AORUS ULTRA
-# SIV 0xA2030607
-# Motherboards:
-#   B860M D2H
-#   B860M POWER
-chip "it8696_a1030607-*" "it8696_a2030607-*"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label temp6   "System 2"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN"
-    label fan5    "CPU_OPT"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN"
-    label pwm5    "CPU_OPT"
-
-# SIV 0xA1060607
-# Motherboards:
-#   Z890 AORUS ELITE DUO X
-#   Z890 AORUS ELITE WIFI7 PLUS
-#   Z890 EAGLE PLUS
-#   Z890 EAGLE WIFI7 PLUS
-chip "it8696_a1060607-*"
-    label temp1   "System 1"
-    label temp2   "VRM MOS"
-    label temp3   "CPU"
-    label temp4   "X16"
-    label temp5   "PCH"
-    label temp6   "System 2"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2"
-    label fan4    "SYS_FAN3"
-    label fan5    "CPU_OPT"
-    label fan6    "SYS_FAN4_PUMP"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2"
-    label pwm4    "SYS_FAN3"
-    label pwm5    "CPU_OPT"
-    label pwm6    "SYS_FAN4_PUMP"
-
-# SIV 0xA1040607
-# Motherboards:
-#   Q870M D3H
-#   Z890M?
-chip "it8698_a1040607-*"
-    label temp1   "System 1"
-    label temp2   "PCH"
-    label temp3   "CPU"
-    label temp4   "PCIEX16"
-    label temp5   "VRM MOS"
-    label temp6   "System 2"
-    label fan1    "CPU_FAN"
-    label fan2    "SYS_FAN1"
-    label fan3    "SYS_FAN2_PUMP"
-    label fan6    "CPU_OPT"
-    label pwm1    "CPU_FAN"
-    label pwm2    "SYS_FAN1"
-    label pwm3    "SYS_FAN2_PUMP"
-    label pwm6    "CPU_OPT"
-
-# SIV 0x1005060B
-# Motherboards:
-#   GA-Z270X-Gaming 5
-#   GA-Z270X-Gaming K7
-#   GA-Z270X-GAMING SOC
-chip "it8792_1005060b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-
-# SIV 0x1006090B
-# Motherboards:
-#   GA-Z270X-UD5
-chip "it8792_1006090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN4_PUMP"
-    label fan2    "SYS_FAN2"
-    label fan3    "SYS_FAN3"
-    label pwm1    "SYS_FAN4_PUMP"
-    label pwm2    "SYS_FAN2"
-    label pwm3    "SYS_FAN3"
-
-# SIV 0x1008090B
-# Motherboards:
-#   GA-Z270X-Gaming 7
-#   GA-Z270X-Gaming 8
-# SIV 0x7008090B
-# Motherboards:
-#   Z590 AORUS PRO AX
-# SIV 0x7108090B
-# Motherboards:
-#   Z590 VISION D
-# SIV 0x7208090B
-# Motherboards:
-#   Z590 AORUS TACHYON
-# SIV 0x7308090B
-# Motherboards:
-#   Z590 AORUS ULTRA
-chip "it8792_1008090b-*" "it87952_7008090b-*" "it87952_7108090b-*" "it87952_7208090b-*" "it87952_7308090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x1108090B
-# Motherboards:
-#   GA-Z270X-Gaming 9
-chip "it8792_1108090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX16_2"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x20050809
-# Motherboards:
-#   X299 AORUS Gaming
-chip "it8792_20050809-*"
-    label in1     "DDRVPP CH(A/B)"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
     compute in1   @ * 1.649, @ / 1.649
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label temp1   "PCIEX16_2"
-    label temp3   "System 2"
-    label fan1    "HPWR_FAN_PUMP"
-    label pwm1    "HPWR_FAN_PUMP"
-
-# SIV 0x2308090B
-# Motherboards:
-#   Motherboards: Names not currently known.
-# SIV 0x2408090B
-# Motherboards:
-#   C621 AORUS XTREME
-chip "it8792_2308090b-*" "it8792_2408090b-*"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B/C)"
-    compute in5   @ * 1.649, @ / 1.649
-    label in8     "DDRVPP CH(D/E/F)"
-    compute in8   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX16_2"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN6_PUMP"
-    label fan2    "SYS_FAN5_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN6_PUMP"
-    label pwm2    "SYS_FAN5_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x3008090B
-# Motherboards:
-#   Z370 AORUS GAMING 5
-# SIV 0x3108090B
-# Motherboards:
-#   Z370 AORUS GAMING 7
-#   Z370 AORUS GAMING 7-OP
-chip "it8792_3008090b-*" "it8792_3108090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "HPWR_FAN_PUMP"
-    label fan2    "SYS_FAN5_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "HPWR_FAN_PUMP"
-    label pwm2    "SYS_FAN5_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x4006090B
-# Motherboards:
-#   Motherboards: Names not currently known.
-# SIV 0x4106090B
-# Motherboards:
-#   Motherboards: Names not currently known.
-# SIV 0x6306090B
-# Motherboards:
-#   Motherboards: Names not currently known.
-# SIV 0x6406090B
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it8792_4006090b-*" "it8792_4106090b-*" "it8792_6306090b-*" "it8792_6406090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN3_PUMP"
-    label fan2    "SYS_FAN4_PUMP"
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "System 2"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
     label fan3    "SYS_FAN2"
-    label pwm1    "SYS_FAN3_PUMP"
-    label pwm2    "SYS_FAN4_PUMP"
+    label fan4    "SYS_FAN3"
+    label fan5    "CPU_OPT"
+    label fan6    "SYS_FAN4_PUMP"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
     label pwm3    "SYS_FAN2"
+    label pwm4    "SYS_FAN3"
+    label pwm5    "CPU_OPT"
+    label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
 
-# SIV 0x4008090A
+# SIV 0xA008090B
 # Motherboards:
-#   Z390 AORUS XTREME WATERFORCE
-#   Z390 AORUS XTREME WATERFORCE 5G
-# SIV 0x6108090A
+#   Z890 AORUS ELITE X ICE
+#   Z890 AORUS PRO ICE
+# SIV 0xA009090B
 # Motherboards:
-#   Z490 AORUS XTREME WATERFORCE
-chip "it8792_4008090a-*" "it8792_6108090a-*"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN6_PUMP"
-    label fan2    "SYS_FAN5_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN6_PUMP"
-    label pwm2    "SYS_FAN5_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x4008090B
+#   Z890 AORUS TACHYON DUO X ICE
+#   Z890 AORUS TACHYON ICE
+# SIV 0xA00A090B
 # Motherboards:
-#   Z390 AORUS MASTER
-#   Z390 AORUS MASTER G2 EDITION
-#   Z390 AORUS PRO
-#   Z390 AORUS PRO WIFI
-#   Z390 AORUS ULTRA
-#   Z390 AORUS XTREME
-# SIV 0x6008090B
+#   Z890 AORUS MASTER
+# SIV 0xA00B090B
 # Motherboards:
-#   Z490 AORUS PRO AX
-#   Z490 VISION D
-# SIV 0x6208090B
+#   Z890 AORUS XTREME AI TOP
+# SIV 0xA108090B
 # Motherboards:
-#   Z490 AORUS MASTER
-#   Z490 AORUS ULTRA
-#   Z490 AORUS ULTRA G2
-#   Z490 AORUS XTREME
-# SIV 0x6308090B
+#   W880 AI TOP
+#   Z890 AERO D
+#   Z890 AI TOP
+# SIV 0xA10A090B
 # Motherboards:
-#   W480 VISION D
-# SIV 0x6508090B
-# Motherboards:
-#   Z490 AORUS MASTER WATERFORCE
-chip "it8792_4008090b-*" "it8792_6008090b-*" "it8792_6208090b-*" "it8792_6308090b-*" "it8792_6508090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN6_PUMP"
-    label fan2    "SYS_FAN5_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN6_PUMP"
-    label pwm2    "SYS_FAN5_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x7106090B
-# Motherboards:
-#   Z590 VISION G
-chip "it87952_7106090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan3    "SYS_FAN4"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x710A090A
-# Motherboards:
-#   Z590 AORUS XTREME WATERFORCE
-chip "it87952_710a090a-*"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
-
-# SIV 0x710A090B
-# Motherboards:
-#   Z590 AORUS XTREME
-# SIV 0x720A090B
-# Motherboards:
-#   Z590 AORUS MASTER
-# SIV 0x730A090B
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it87952_710a090b-*" "it87952_720a090b-*" "it87952_730a090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH Core"
-    label in4     "CPU VCCIO"
-    label in5     "DDRVPP CH(A/B)"
-    compute in5   @ * 1.649, @ / 1.649
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
-
-# SIV 0x8008090A
-# Motherboards:
-#   Z690 AERO D
-#   Z690 AORUS TACHYON
-# SIV 0x9108090A
-# Motherboards:
-#   Z790 AORUS TACHYON
-#   Z790 AORUS TACHYON X
-chip "it87952_8008090a-*" "it87952_9108090a-*"
-    label in1     "CPU VDD2"
-    label in2     "PCH 0.82V"
-    label in4     "CPU VCCSA"
-    label in5     "PCH 1.8V"
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x8008090B
-# Motherboards:
-#   B660 AORUS MASTER DDR4
-#   Z690 AERO G DDR4
-#   Z690 AORUS PRO DDR4
-# SIV 0x9008090B
-# Motherboards:
-#   B760 AORUS MASTER DDR4
-chip "it87952_8008090b-*" "it87952_9008090b-*"
-    label in1     "DDRVTT CH(A/B)"
-    label in2     "PCH 0.82V"
-    label in4     "CPU VCCSA"
-    label in5     "PCH 1.8V"
-    label temp1   "PCIEX4"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x800A0909
-# Motherboards:
-#   Z690 AORUS XTREME WATERFORCE
-chip "it87952_800a0909-*"
-    label in2     "PCH 0.82V"
-    label in4     "CPU VCCSA"
-    label in5     "PCH 1.8V"
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
-
-# SIV 0x800A090A
-# Motherboards:
-#   Z690 AORUS XTREME
-chip "it87952_800a090a-*"
-    label in1     "CPU VDD2"
-    label in2     "PCH 0.82V"
-    label in4     "CPU VCCSA"
-    label in5     "PCH 1.8V"
-    label temp1   "PCIEX8"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
-
-# SIV 0x8108090A
-# Motherboards:
-#   B660 AORUS MASTER
-#   Z690 AERO G
-#   Z690 AORUS PRO
-#   Z690 AORUS ULTRA
-# SIV 0x9008090A
-# Motherboards:
-#   Z790 AERO G
-#   Z790 AORUS PRO X
-#   Z790 AORUS PRO X WIFI7
-chip "it87952_8108090a-*" "it87952_9008090a-*"
-    label in1     "CPU VDD2"
-    label in2     "PCH 0.82V"
-    label in4     "CPU VCCSA"
-    label in5     "PCH 1.8V"
-    label temp1   "PCIEX4"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-
-# SIV 0x810A090A
-# Motherboards:
-#   Z690 AORUS MASTER
-# SIV 0x900A090A
-# Motherboards:
-#   Z790 AORUS MASTER
-#   Z790 AORUS MASTER X
-# SIV 0x910A090A
-# Motherboards:
-#   Z790 AORUS XTREME
-#   Z790 AORUS XTREME X
-#   Z790 AORUS XTREME X ICE
-chip "it87952_810a090a-*" "it87952_900a090a-*" "it87952_910a090a-*"
-    label in1     "CPU VDD2"
-    label in2     "PCH 0.82V"
-    label in4     "CPU VCCSA"
-    label in5     "PCH 1.8V"
-    label temp1   "PCIEX4"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
-
-# SIV 0x900A0909
-# Motherboards:
-#   Motherboards: Names not currently known.
-chip "it87952_900a0909-*"
-    label in2     "PCH 0.82V"
-    label in4     "CPU VCCSA"
-    label in5     "PCH 1.8V"
-    label temp1   "PCIEX4"
-    label temp2   "EC_TEMP2"
-    label temp3   "System 2"
-    label fan1    "SYS_FAN5_PUMP"
-    label fan2    "SYS_FAN6_PUMP"
-    label fan3    "SYS_FAN4"
-    label fan4    "SYS_FAN7_PUMP"
-    label fan5    "SYS_FAN8_PUMP"
-    label pwm1    "SYS_FAN5_PUMP"
-    label pwm2    "SYS_FAN6_PUMP"
-    label pwm3    "SYS_FAN4"
-    label pwm4    "SYS_FAN7_PUMP"
-    label pwm5    "SYS_FAN8_PUMP"
+#   Z890 AORUS MASTER AI TOP
+chip "it8696_a008090b-*" "it8696_a009090b-*" "it8696_a00a090b-*" "it8696_a00b090b-*" "it8696_a108090b-*" "it8696_a10a090b-*"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "EC_TEMP1"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label fan4    "SYS_FAN3"
+    label fan5    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    label pwm4    "SYS_FAN3"
+    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0xA008090B
 # Motherboards:
@@ -2842,6 +3353,12 @@ chip "it87952_a008090b-*"
     label pwm1    "SYS_FAN5_PUMP"
     label pwm2    "SYS_FAN6_PUMP"
     label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0xA009090B
 # Motherboards:
@@ -2863,6 +3380,46 @@ chip "it87952_a009090b-*"
     label pwm2    "SYS_FAN6_PUMP"
     label pwm3    "SYS_FAN4"
     label pwm4    "SYS_FAN7_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0xA00A080B
+# Motherboards:
+#   W790 AI TOP
+chip "it8696_a00a080b-*"
+    label in0     "VCCIN"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "VCCVNN"
+    label in5     "PCH 0.82V"
+    label in6     "PCH 1.8V"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "EC_TEMP1"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label fan4    "SYS_FAN3"
+    label fan5    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    label pwm4    "SYS_FAN3"
+    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan6
+    ignore pwm6
 
 # SIV 0xA00A080B
 # Motherboards:
@@ -2884,6 +3441,13 @@ chip "it87952_a00a080b-*"
     label pwm3    "SYS_FAN4"
     label pwm4    "VRM 1"
     label pwm5    "VRM 2"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+    ignore temp1
 
 # SIV 0xA00A090B
 # Motherboards:
@@ -2906,6 +3470,12 @@ chip "it87952_a00a090b-*"
     label pwm3    "SYS_FAN4"
     label pwm4    "SYS_FAN7_PUMP"
     label pwm5    "SYS_FAN8_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0xA00B090B
 # Motherboards:
@@ -2930,6 +3500,157 @@ chip "it87952_a00b090b-*"
     label pwm4    "SYS_FAN7_PUMP"
     label pwm5    "SYS_FAN8_PUMP"
     label pwm6    "DDR_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
+
+# SIV 0xA1020407
+# Motherboards:
+#   Motherboards: Names not currently known.
+chip "it8696_a1020407-*"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp5   "VRM MOS"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1_PUMP"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore temp4
+    ignore temp6
+    ignore fan3
+    ignore fan4
+    ignore fan5
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm5
+    ignore pwm6
+
+# SIV 0xA1030607
+# Motherboards:
+#   B860I AORUS PRO ICE
+#   Z890I AORUS ULTRA
+# SIV 0xA2030607
+# Motherboards:
+#   B860M D2H
+#   B860M POWER
+chip "it8696_a1030607-*" "it8696_a2030607-*"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "System 2"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN"
+    label fan5    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN"
+    label pwm5    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan3
+    ignore fan4
+    ignore fan6
+    ignore pwm3
+    ignore pwm4
+    ignore pwm6
+
+# SIV 0xA1040607
+# Motherboards:
+#   Q870M D3H
+#   Z890M?
+chip "it8698_a1040607-*"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
+    label temp1   "System 1"
+    label temp2   "PCH"
+    label temp3   "CPU"
+    label temp4   "PCIEX16"
+    label temp5   "VRM MOS"
+    label temp6   "System 2"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2_PUMP"
+    label fan6    "CPU_OPT"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2_PUMP"
+    label pwm6    "CPU_OPT"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore fan4
+    ignore fan5
+    ignore pwm4
+    ignore pwm5
+
+# SIV 0xA1060607
+# Motherboards:
+#   Z890 AORUS ELITE DUO X
+#   Z890 AORUS ELITE WIFI7 PLUS
+#   Z890 EAGLE PLUS
+#   Z890 EAGLE WIFI7 PLUS
+chip "it8696_a1060607-*"
+    label in0     "CPU VCore"
+    label in1     "+3.3V"
+    compute in1   @ * 1.649, @ / 1.649
+    label in2     "+12V"
+    compute in2   @ * 6, @ / 6
+    label in3     "+5V"
+    compute in3   @ * 2.5, @ / 2.5
+    label in4     "CPU VAXG"
+    label in5     "CPU VNNAON"
+    label in6     "CPU VCCSA"
+    label temp1   "System 1"
+    label temp2   "VRM MOS"
+    label temp3   "CPU"
+    label temp4   "X16"
+    label temp5   "PCH"
+    label temp6   "System 2"
+    label fan1    "CPU_FAN"
+    label fan2    "SYS_FAN1"
+    label fan3    "SYS_FAN2"
+    label fan4    "SYS_FAN3"
+    label fan5    "CPU_OPT"
+    label fan6    "SYS_FAN4_PUMP"
+    label pwm1    "CPU_FAN"
+    label pwm2    "SYS_FAN1"
+    label pwm3    "SYS_FAN2"
+    label pwm4    "SYS_FAN3"
+    label pwm5    "CPU_OPT"
+    label pwm6    "SYS_FAN4_PUMP"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
 
 # SIV 0xA108090B
 # Motherboards:
@@ -2950,6 +3671,12 @@ chip "it87952_a108090b-*"
     label pwm1    "FAN5_PUMP"
     label pwm2    "FAN6_PUMP"
     label pwm3    "SYS_FAN4"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8
 
 # SIV 0xA10A090B
 # Motherboards:
@@ -2974,3 +3701,9 @@ chip "it87952_a10a090b-*"
     label pwm4    "SYS_FAN7_PUMP"
     label pwm5    "SYS_FAN8_PUMP"
     label pwm6    "DDR_FAN"
+    # Hide only chip-supported channels not mapped by this SIV configuration.
+    ignore in0
+    ignore in5
+    ignore in6
+    ignore in7
+    ignore in8


### PR DESCRIPTION
@frankcrawford I've fixed some entries that ended up being split between multiple superios incorrectly. I've also updated things so that sensors that aren't attached are ignored.